### PR TITLE
Fix USB connections on Windows

### DIFF
--- a/src/CommonFunctions.h
+++ b/src/CommonFunctions.h
@@ -1,10 +1,21 @@
 #pragma once
 
 #include <string>
+#include <sstream>
+#include <iomanip>
 
 #include "limesuiteng/commonTypes.h"
 
 namespace lime {
+
 const std::string strFormat(const char* format, ...);
 std::string ToString(TRXDir dir);
+
+template<typename T> std::string intToHex(T i)
+{
+    std::stringstream stream;
+    stream << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << i;
+    return stream.str();
+}
+
 } // namespace lime

--- a/src/boards/DeviceFactoryFX3.cpp
+++ b/src/boards/DeviceFactoryFX3.cpp
@@ -5,6 +5,7 @@
 #include "LMS64C_LMS7002M_Over_USB.h"
 #include "LMS64C_FPGA_Over_USB.h"
 #include "Logger.h"
+#include "CommonFunctions.h"
 
 #include <memory>
 #include <stdexcept>
@@ -24,6 +25,8 @@
 #endif
 
 using namespace lime;
+using namespace std::literals::string_literals;
+using namespace std::literals::string_view_literals;
 
 void __loadFX3(void) //TODO fixme replace with LoadLibrary/dlopen
 {
@@ -34,7 +37,7 @@ void __loadFX3(void) //TODO fixme replace with LoadLibrary/dlopen
 static const std::set<VidPid> ids{ { 1204, 241 }, { 1204, 243 }, { 7504, 24840 } };
 
 DeviceFactoryFX3::DeviceFactoryFX3()
-    : USBEntry("FX3", ids)
+    : USBEntry("FX3"s, ids)
 {
 }
 
@@ -42,7 +45,7 @@ DeviceFactoryFX3::DeviceFactoryFX3()
 std::vector<DeviceHandle> DeviceFactoryFX3::enumerate(const DeviceHandle& hint)
 {
     std::vector<DeviceHandle> handles;
-    if (!hint.media.empty() && hint.media.find("USB") == std::string::npos)
+    if (!hint.media.empty() && hint.media.find("USB"sv) == std::string::npos)
     {
         return handles;
     }
@@ -57,14 +60,19 @@ std::vector<DeviceHandle> DeviceFactoryFX3::enumerate(const DeviceHandle& hint)
             device.Open(i);
             DeviceHandle handle;
             if (device.bSuperSpeed == true)
-                handle.media = "USB 3.0";
+                handle.media = "USB 3.0"s;
             else if (device.bHighSpeed == true)
-                handle.media = "USB 2.0";
+                handle.media = "USB 2.0"s;
             else
-                handle.media = "USB";
+                handle.media = "USB"s;
+
+            uint16_t vendorId = device.VendorID;
+            uint16_t productId = device.ProductID;
             handle.name = device.DeviceName;
             std::wstring ws(device.SerialNumber);
             handle.serial = std::string(ws.begin(), ws.end());
+            handle.addr = intToHex(vendorId) + ':' + intToHex(productId);
+
             if (hint.serial.empty() or handle.serial.find(hint.serial) != std::string::npos)
                 handles.push_back(handle); //filter on serial
             device.Close();
@@ -83,7 +91,7 @@ SDRDevice* DeviceFactoryFX3::make_LimeSDR(const DeviceHandle& handle, const uint
     );
     if (!usbComms->Connect(vid, pid, handle.serial))
     {
-        const std::string reason = "Unable to connect to device using handle (" + handle.Serialize() + ")";
+        const std::string reason = "Unable to connect to device using handle ("s + handle.Serialize() + ")"s;
         throw std::runtime_error(reason);
     }
 
@@ -98,7 +106,7 @@ SDRDevice* DeviceFactoryFX3::make_LimeSDR(const DeviceHandle& handle, const uint
 
 SDRDevice* DeviceFactoryFX3::make(const DeviceHandle& handle)
 {
-    const auto splitPos = handle.addr.find(":");
+    const auto splitPos = handle.addr.find(':');
     uint16_t vid = 0;
     uint16_t pid = 0;
 

--- a/src/boards/DeviceRegistry.cpp
+++ b/src/boards/DeviceRegistry.cpp
@@ -46,7 +46,7 @@ SDRDevice* DeviceRegistry::makeDevice(const DeviceHandle& handle)
             continue;
 
         auto realHandle = r.front(); //just pick the first
-        return entry.second->make(handle);
+        return entry.second->make(realHandle);
     }
 
     const std::string reason = "No devices found with given handle (" + handle.Serialize() + ")";

--- a/src/comms/USB/USBEntry.cpp
+++ b/src/comms/USB/USBEntry.cpp
@@ -1,5 +1,6 @@
 #include "USBEntry.h"
 #include "Logger.h"
+#include "CommonFunctions.h"
 
 using namespace lime;
 
@@ -135,11 +136,7 @@ DeviceHandle USBEntry::GetDeviceHandle(
         handle.name = std::string(characterBuffer, size_t(descriptorStringLength));
     }
 
-    int addressLength = std::sprintf(characterBuffer, "%.4x:%.4x", desc.idVendor, desc.idProduct);
-    if (addressLength > 0)
-    {
-        handle.addr = std::string(characterBuffer, size_t(addressLength));
-    }
+    handle.addr = intToHex(desc.idVendor) + ':' + intToHex(desc.idProduct);
 
     if (desc.iSerialNumber > 0)
     {


### PR DESCRIPTION
# Fixed
- USB connection logic on Windows

# Added
- Common function to convert an integer to a hex string

# Changed
- Use string literals in USB connection code
- Linux code also uses the same function to convert an integer to a hex ID