### PR TITLE
Replace LPF tune algorithm with arithmetic

### DIFF
--- a/plugins/amarisoft-plugin/common.cpp
+++ b/plugins/amarisoft-plugin/common.cpp
@@ -757,8 +757,7 @@ static void TransferRuntimeParametersToConfig(
         trxConfig.centerFrequency = params.freq[i];
         if (trxConfig.gfir.bandwidth == 0) // update only if not set by settings file
             trxConfig.gfir.bandwidth = params.bandwidth[i];
-        if (trxConfig.calibrate)
-            trxConfig.lpf = params.bandwidth[i];
+        trxConfig.lpf = params.bandwidth[i];
 
         const int chipIndex = channelMap[i].parent->chipIndex;
         const auto& desc = channelMap[i].parent->device->GetDescriptor().rfSOC[chipIndex];

--- a/src/boards/LMS7002M_SDRDevice.cpp
+++ b/src/boards/LMS7002M_SDRDevice.cpp
@@ -406,12 +406,12 @@ OpStatus LMS7002M_SDRDevice::SetLowPassFilter(uint8_t moduleIndex, TRXDir trx, u
     if (tx)
     {
         int gain = lms->GetTBBIAMP_dB(ch);
-        status = lms->TuneTxFilter(lpf);
+        status = lms->SetTxLPF(lpf);
         lms->SetTBBIAMP_dB(gain, ch);
     }
     else
     {
-        status = lms->TuneRxFilter(lpf);
+        status = lms->SetRxLPF(lpf);
     }
 
     if (status != OpStatus::Success)
@@ -1241,17 +1241,15 @@ OpStatus LMS7002M_SDRDevice::LMS7002ChannelCalibration(LMS7002M* chip, const Cha
     }
     if (ch.rx.lpf > 0 && ch.rx.enabled)
     {
-        SetupCalibrations(chip, ch.rx.sampleRate);
-        int status = TuneRxFilter(ch.rx.lpf);
-        if (status != MCU_BD::MCU_NO_ERROR)
-            return lime::ReportError(OpStatus::Error, "Rx ch%i filter calibration failed: %s", i, MCU_BD::MCUStatusMessage(status));
+        OpStatus status = chip->SetRxLPF(ch.rx.lpf);
+        if (status != OpStatus::Success)
+            return lime::ReportError(status, "Rx ch%i filter calibration failed: %s", i, GetLastErrorMessage());
     }
     if (ch.tx.lpf > 0 && ch.tx.enabled)
     {
-        SetupCalibrations(chip, ch.tx.sampleRate);
-        int status = TuneTxFilter(ch.tx.lpf);
-        if (status != MCU_BD::MCU_NO_ERROR)
-            return lime::ReportError(OpStatus::Error, "Tx ch%i filter calibration failed: %s", i, MCU_BD::MCUStatusMessage(status));
+        OpStatus status = chip->SetTxLPF(ch.tx.lpf);
+        if (status != OpStatus::Success)
+            return lime::ReportError(status, "Tx ch%i filter calibration failed: %s", i, GetLastErrorMessage());
     }
     return OpStatus::Success;
 }

--- a/src/include/limesuiteng/LMS7002M.h
+++ b/src/include/limesuiteng/LMS7002M.h
@@ -294,11 +294,25 @@ class LIME_API LMS7002M
     OpStatus TuneTxFilter(const float_type tx_lpf_freq_RF);
 
     /**
+     * @brief Set transmitter analog Low Pass Filter.
+     * @param rfBandwidth_Hz filter's RF bandwidth in Hz.
+     * @return The status of the operation
+     */
+    OpStatus SetTxLPF(double rfBandwidth_Hz);
+
+    /**
      * @brief Tunes the Low Pass Filter for the RX direction.
      * @param rx_lpf_freq_RF The frequency (in Hz) to tune the filter to.
      * @return The status of the operation
      */
     OpStatus TuneRxFilter(const float_type rx_lpf_freq_RF);
+
+    /**
+     * @brief Set receiver analog Low Pass Filter.
+     * @param rfBandwidth_Hz filter's RF bandwidth in Hz.
+     * @return The status of the operation
+     */
+    OpStatus SetRxLPF(double rfBandwidth_Hz);
 
     /*!
      * @brief Calibrates the internal Analog to Digital Converter on the chip.

--- a/src/lms7002_wxgui/lms7002_pnlRBB_view.cpp
+++ b/src/lms7002_wxgui/lms7002_pnlRBB_view.cpp
@@ -7,6 +7,7 @@
 #include "lms7suiteEvents.h"
 #include "lms7suiteAppFrame.h"
 #include "limesuiteng/Logger.h"
+#include "limesuiteng/LMS7002M.h"
 #include "limesuiteng/LMS7002M_parameters.h"
 
 using namespace lime;
@@ -509,16 +510,11 @@ void lms7002_pnlRBB_view::UpdateGUI()
 
 void lms7002_pnlRBB_view::OnbtnTuneFilter(wxCommandEvent& event)
 {
-    double input1;
-    txtLowBW_MHz->GetValue().ToDouble(&input1);
+    double bandwidth_MHz;
+    txtLowBW_MHz->GetValue().ToDouble(&bandwidth_MHz);
 
-    // int status;
-    // uint16_t ch;
-    // TODO: status = LMS_SetLPFBW(lmsControl, LMS_CH_RX, mChannel, input1 * 1e6);
-    // if (status != 0){
-    //     wxMessageBox(wxString(_("Rx Filter tune failed")), _("Error"));
-    //     return;
-    // }
-    // LMS_Synchronize(lmsControl,false);
+    OpStatus status = lmsControl->SetRxLPF(bandwidth_MHz * 1e6);
+    if (status != OpStatus::Success)
+        wxMessageBox(wxString(_("Error setting Rx Filter")), _("Error"));
     UpdateGUI();
 }

--- a/src/lms7002_wxgui/lms7002_pnlTBB_view.cpp
+++ b/src/lms7002_wxgui/lms7002_pnlTBB_view.cpp
@@ -605,14 +605,11 @@ void lms7002_pnlTBB_view::UpdateGUI()
 
 void lms7002_pnlTBB_view::OnbtnTuneFilter(wxCommandEvent& event)
 {
-    double input1;
-    txtFilterFrequency->GetValue().ToDouble(&input1);
-    // TOOD: int status = lmsControl->SetLPF(true, mChannel, true, input1 * 1e6);
-    // if (status != 0) {
-    //     wxMessageBox(wxString(_("Tx calibration failed")));
-    //     return;
-    // }
-    // LMS_Synchronize(lmsControl,false);
+    double bandwidth_MHz;
+    txtFilterFrequency->GetValue().ToDouble(&bandwidth_MHz);
+    OpStatus status = lmsControl->SetTxLPF(bandwidth_MHz * 1e6);
+    if (status != OpStatus::Success)
+        wxMessageBox(wxString(_("Error setting Tx filter")));
     UpdateGUI();
 }
 

--- a/src/lms7002m/LMS7002M.cpp
+++ b/src/lms7002m/LMS7002M.cpp
@@ -3371,7 +3371,7 @@ OpStatus LMS7002M::SetRxLPF(double rfBandwidth_Hz)
     {
         lime::info("RxLPF bypassed");
         powerDowns = 0xD;
-        input_ctl_pga_rbb = 4;
+        input_ctl_pga_rbb = 2;
     }
     else if (rfBandwidth_Hz < rxLpfMin)
     {
@@ -3401,7 +3401,7 @@ OpStatus LMS7002M::SetRxLPF(double rfBandwidth_Hz)
     else if (30e6 <= rfBandwidth_Hz && rfBandwidth_Hz <= rxLpfMax)
     {
         powerDowns = 0x5;
-        input_ctl_pga_rbb = 2;
+        input_ctl_pga_rbb = 1;
     }
 
     Modify_SPI_Reg_bits(LMS7_CFB_TIA_RFE, cfb_tia_rfe);
@@ -3430,6 +3430,7 @@ OpStatus LMS7002M::SetTxLPF(double rfBandwidth_Hz)
     Modify_SPI_Reg_bits(LMS7_CCAL_LPFLAD_TBB, 31);
     Modify_SPI_Reg_bits(LMS7_RCAL_LPFS5_TBB, 255);
     Modify_SPI_Reg_bits(LMS7_R5_LPF_BYP_TBB, 1);
+    Modify_SPI_Reg_bits(LMS7_BYPLADDER_TBB, 0);
 
     uint16_t powerDowns = 0x15; // addr 0x0105[4:0]
 

--- a/src/lms7002m/LMS7002M.cpp
+++ b/src/lms7002m/LMS7002M.cpp
@@ -3352,7 +3352,7 @@ OpStatus LMS7002M::SetRxLPF(double rfBandwidth_Hz)
     uint16_t powerDowns = 0xD; // 0x0115[3:0]
 
     const double ifbw = bandwidth_MHz / 2 / 0.75;
-    const uint16_t rcc_ctl_lpfh_rbb = std::clamp(ifbw/10 - 2, 0.0, 7.0);
+    const uint16_t rcc_ctl_lpfh_rbb = std::clamp(ifbw / 10 - 2, 0.0, 7.0);
     uint16_t rcc_ctl_lpfl_rbb = 5;
     if (ifbw >= 20)
         rcc_ctl_lpfl_rbb = 5;

--- a/src/lms7002m/LMS7002M.cpp
+++ b/src/lms7002m/LMS7002M.cpp
@@ -3352,7 +3352,7 @@ OpStatus LMS7002M::SetRxLPF(double rfBandwidth_Hz)
     uint16_t powerDowns = 0xD; // 0x0115[3:0]
 
     const double ifbw = bandwidth_MHz / 2 / 0.75;
-    const uint16_t rcc_ctl_lpfh_rbb = std::clamp(ifbw - 2, 0.0, 7.0);
+    const uint16_t rcc_ctl_lpfh_rbb = std::clamp(ifbw/10 - 2, 0.0, 7.0);
     uint16_t rcc_ctl_lpfl_rbb = 5;
     if (ifbw >= 20)
         rcc_ctl_lpfl_rbb = 5;

--- a/src/lms7002m/LMS7002M.cpp
+++ b/src/lms7002m/LMS7002M.cpp
@@ -3306,7 +3306,7 @@ OpStatus LMS7002M::SetRxLPF(double rfBandwidth_Hz)
     Modify_SPI_Reg_bits(LMS7_RCC_CTL_PGA_RBB, 0x18);
     Modify_SPI_Reg_bits(LMS7_C_CTL_PGA_RBB, 1);
 
-    const double rxLpfMin = (tiaGain == 1) ? 1.5e6 : 4e6;
+    const double rxLpfMin = (tiaGain == 1) ? 4e6 : 1.5e6;
     const double rxLpfMax = 160e6;
     if (rfBandwidth_Hz != 0 && (rfBandwidth_Hz < rxLpfMin || rfBandwidth_Hz > rxLpfMax))
     {
@@ -3410,7 +3410,7 @@ OpStatus LMS7002M::SetRxLPF(double rfBandwidth_Hz)
     Modify_SPI_Reg_bits(0x0115, 3, 0, powerDowns);
     Modify_SPI_Reg_bits(LMS7_INPUT_CTL_PGA_RBB, input_ctl_pga_rbb);
     Modify_SPI_Reg_bits(LMS7_C_CTL_LPFL_RBB, c_ctl_lpfl_rbb);
-    Modify_SPI_Reg_bits(LMS7_C_CTL_LPFL_RBB, c_ctl_lpfh_rbb);
+    Modify_SPI_Reg_bits(LMS7_C_CTL_LPFH_RBB, c_ctl_lpfh_rbb);
     Modify_SPI_Reg_bits(LMS7_RCC_CTL_LPFL_RBB, rcc_ctl_lpfl_rbb);
     Modify_SPI_Reg_bits(LMS7_RCC_CTL_LPFH_RBB, rcc_ctl_lpfh_rbb);
 
@@ -3438,6 +3438,7 @@ OpStatus LMS7002M::SetTxLPF(double rfBandwidth_Hz)
         lime::info("TxLPF bypassed");
         powerDowns = 0x15;
         Modify_SPI_Reg_bits(0x0105, 4, 0, powerDowns);
+        Modify_SPI_Reg_bits(LMS7_BYPLADDER_TBB, 1);
         return Modify_SPI_Reg_bits(LMS7_RCAL_LPFS5_TBB, 0);
     }
     else if (rfBandwidth_Hz < txLpfLowRange[0] || txLpfHighRange[1] < rfBandwidth_Hz)

--- a/src/lms7002m/LMS7002M.cpp
+++ b/src/lms7002m/LMS7002M.cpp
@@ -3291,7 +3291,7 @@ OpStatus LMS7002M::SetRxLPF(double rfBandwidth_Hz)
     Modify_SPI_Reg_bits(LMS7_ICT_TIAMAIN_RFE, 2);
     Modify_SPI_Reg_bits(LMS7_ICT_TIAOUT_RFE, 2);
 
-    Modify_SPI_Reg_bits(LMS7_ICT_LPF_IN_RBB, 0x04);
+    Modify_SPI_Reg_bits(LMS7_ICT_LPF_IN_RBB, 0x0C);
     Modify_SPI_Reg_bits(LMS7_ICT_LPF_OUT_RBB, 0x0C);
 
     Modify_SPI_Reg_bits(LMS7_ICT_PGA_OUT_RBB, 0x14);


### PR DESCRIPTION
Added functions to calculate LPF controls based on requested bandwidth without requiring runtime tuning algorithm.