### PR TITLE
Fix GNU Radio in-tree building

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -17,13 +17,7 @@ add_subdirectory(SoapyLMS7)
 ########################################################################
 ## GNU Radio plugin
 ########################################################################
-find_package(Gnuradio QUIET) # precheck if any gnuradio package is available
-cmake_dependent_option(
-    ENABLE_GNURADIO "Build LimeSuiteNG plugin for GNU Radio" ON "ENABLE_LIBRARY;Gnuradio_FOUND;BUILD_SHARED_LIBS" OFF)
-add_feature_info(GNURADIO ENABLE_GNURADIO "GNU Radio 3.9+ Plug-in")
-if(ENABLE_GNURADIO)
-    add_subdirectory(gr-limesdr)
-endif()
+add_subdirectory(gr-limesdr)
 
 ########################################################################
 ## HDSDR plugin

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -17,7 +17,12 @@ add_subdirectory(SoapyLMS7)
 ########################################################################
 ## GNU Radio plugin
 ########################################################################
-add_subdirectory(gr-limesdr)
+include(CMakeDependentOption)
+cmake_dependent_option(ENABLE_GNURADIO_PREREQ "Build LimeSuiteNG plugin for GNU Radio" ON "ENABLE_LIBRARY;BUILD_SHARED_LIBS" OFF)
+
+if(ENABLE_GNURADIO_PREREQ)
+    add_subdirectory(gr-limesdr)
+endif()
 
 ########################################################################
 ## HDSDR plugin

--- a/plugins/gr-limesdr/CMakeLists.txt
+++ b/plugins/gr-limesdr/CMakeLists.txt
@@ -15,8 +15,8 @@ enable_testing()
 
 find_package(Gnuradio QUIET) # precheck if any gnuradio package is available
 include(CMakeDependentOption)
-cmake_dependent_option(
-    ENABLE_GNURADIO "Build LimeSuiteNG plugin for GNU Radio" ON "ENABLE_LIBRARY;Gnuradio_FOUND;BUILD_SHARED_LIBS" OFF)
+include(FeatureSummary)
+cmake_dependent_option(ENABLE_GNURADIO "Build LimeSuiteNG plugin for GNU Radio" ON "ENABLE_GNURADIO_PREREQ;Gnuradio_FOUND" OFF)
 add_feature_info(GNURADIO ENABLE_GNURADIO "GNU Radio 3.9+ Plug-in")
 if(NOT ENABLE_GNURADIO)
     return()
@@ -169,7 +169,6 @@ file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_DIR)
 ########################################################################
 # LimeRFE
 ########################################################################
-include(FeatureSummary)
 # RFE Support not added yet
 # option(ENABLE_RFE "Enable LimeRFE support" OFF)
 # add_feature_info(LimeRFE ENABLE_LIBRARY "LimeRFE support")

--- a/plugins/gr-limesdr/CMakeLists.txt
+++ b/plugins/gr-limesdr/CMakeLists.txt
@@ -14,6 +14,7 @@ project(gr-limesdr CXX C)
 enable_testing()
 
 find_package(Gnuradio QUIET) # precheck if any gnuradio package is available
+include(CMakeDependentOption)
 cmake_dependent_option(
     ENABLE_GNURADIO "Build LimeSuiteNG plugin for GNU Radio" ON "ENABLE_LIBRARY;Gnuradio_FOUND;BUILD_SHARED_LIBS" OFF)
 add_feature_info(GNURADIO ENABLE_GNURADIO "GNU Radio 3.9+ Plug-in")
@@ -169,7 +170,6 @@ file(TO_CMAKE_PATH "${PYTHON_NUMPY_INCLUDE_DIR}" PYTHON_NUMPY_INCLUDE_DIR)
 # LimeRFE
 ########################################################################
 include(FeatureSummary)
-include(CMakeDependentOption)
 # RFE Support not added yet
 # option(ENABLE_RFE "Enable LimeRFE support" OFF)
 # add_feature_info(LimeRFE ENABLE_LIBRARY "LimeRFE support")

--- a/plugins/gr-limesdr/CMakeLists.txt
+++ b/plugins/gr-limesdr/CMakeLists.txt
@@ -16,7 +16,7 @@ enable_testing()
 find_package(Gnuradio QUIET) # precheck if any gnuradio package is available
 include(CMakeDependentOption)
 include(FeatureSummary)
-cmake_dependent_option(ENABLE_GNURADIO "Build LimeSuiteNG plugin for GNU Radio" ON "ENABLE_GNURADIO_PREREQ;Gnuradio_FOUND" OFF)
+cmake_dependent_option(ENABLE_GNURADIO "Build LimeSuiteNG plugin for GNU Radio" ON "Gnuradio_FOUND" OFF)
 add_feature_info(GNURADIO ENABLE_GNURADIO "GNU Radio 3.9+ Plug-in")
 if(NOT ENABLE_GNURADIO)
     return()

--- a/plugins/gr-limesdr/CMakeLists.txt
+++ b/plugins/gr-limesdr/CMakeLists.txt
@@ -13,6 +13,14 @@ cmake_minimum_required(VERSION 3.12)
 project(gr-limesdr CXX C)
 enable_testing()
 
+find_package(Gnuradio QUIET) # precheck if any gnuradio package is available
+cmake_dependent_option(
+    ENABLE_GNURADIO "Build LimeSuiteNG plugin for GNU Radio" ON "ENABLE_LIBRARY;Gnuradio_FOUND;BUILD_SHARED_LIBS" OFF)
+add_feature_info(GNURADIO ENABLE_GNURADIO "GNU Radio 3.9+ Plug-in")
+if(NOT ENABLE_GNURADIO)
+    return()
+endif()
+
 # Install to PyBOMBS target prefix if defined
 if(DEFINED ENV{PYBOMBS_PREFIX})
     set(CMAKE_INSTALL_PREFIX $ENV{PYBOMBS_PREFIX})


### PR DESCRIPTION
Running `find_package(Gnuradio)` outside of the `gr-limesdr` project scope permanently sets a few values, which, later on, when trying to actually build the package, looks for files in the wrong place and the compilation fails.