### PR TITLE
Fix Antenna list - missing size only use case

### DIFF
--- a/src/API/LMS_APIWrapper.cpp
+++ b/src/API/LMS_APIWrapper.cpp
@@ -454,9 +454,13 @@ API_EXPORT int CALL_CONV LMS_GetAntennaList(lms_device_t* device, bool dir_tx, s
 
     const auto& rfSOC = apiDevice->GetRFSOCDescriptor();
     const auto& strings = rfSOC.pathNames.at(dir_tx ? lime::TRXDir::Tx : lime::TRXDir::Rx);
-    for (std::size_t i = 0; i < strings.size(); ++i)
+
+    if (list != nullptr)
     {
-        CopyString(strings.at(i), list[i], sizeof(lms_name_t));
+        for (std::size_t i = 0; i < strings.size(); ++i)
+        {
+            CopyString(strings.at(i), list[i], sizeof(lms_name_t));
+        }
     }
 
     return strings.size();


### PR DESCRIPTION
Missing use case
If `list` in `LMS_GetAntennaList` is nullptr we should return how much antennae we have.