### PR TITLE
Fix hanging Windows tests

### DIFF
--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -25,7 +25,7 @@ jobs:
           # os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install linux dependencies
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Configure CMake (linux)
         if: matrix.os != 'windows-latest'
-        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_PREFIX}} -DBUILD_SHARED_LIBS=OFF -DBINARY_OUTPUT_DIR=${{github.workspace}}/build/bin/
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_INSTALL_PREFIX=${{env.INSTALL_PREFIX}} -DBUILD_SHARED_LIBS=OFF -DBINARY_OUTPUT_DIR=${{github.workspace}}/build/bin/ -DENABLE_CODE_COVERAGE=0
 
       - name: Build tests
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target limesuiteng-test

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -8,7 +8,10 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  # TODO: Revert back to Release once the issue is fixed
+  # https://github.com/actions/runner-images/issues/10004
+  # BUILD_TYPE: Release
+  BUILD_TYPE: Debug
   CMAKE_BUILD_PARALLEL_LEVEL: 2
   INSTALL_PREFIX: ${{github.workspace}}/deps
 


### PR DESCRIPTION
# Worked-around
- Hanging Windows tests caused due to an Action Runner update. Related issue: 
https://github.com/actions/runner-images/issues/10004