### PR TITLE
Fix compilation issues on older platforms

### DIFF
--- a/src/boards/DeviceHandle.cpp
+++ b/src/boards/DeviceHandle.cpp
@@ -1,4 +1,5 @@
 #include "limesuiteng/DeviceHandle.h"
+#include <cctype>
 #include <string>
 #include <map>
 

--- a/src/comms/USB/USBGeneric.cpp
+++ b/src/comms/USB/USBGeneric.cpp
@@ -34,7 +34,7 @@ static void HandleLibusbEvents(libusb_context* context)
     {
         int returnCode = libusb_handle_events_timeout_completed(context, &tv, NULL);
         if (returnCode != 0)
-            lime::error("libusb_handle_events: %s", libusb_strerror(returnCode));
+            lime::error("libusb_handle_events: %s", libusb_strerror(static_cast<libusb_error>(returnCode)));
     }
 }
 


### PR DESCRIPTION
# Fixed
- Compilation on Ubuntu 20.04 (seems like that version of `libusb` still needs the conversion to the enum)
- Compilation on VS 2017 (missing `#include`)