### PR TITLE
Add missing feature flag when GNU Radio is not configurable

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -22,6 +22,8 @@ cmake_dependent_option(ENABLE_GNURADIO_PREREQ "Build LimeSuiteNG plugin for GNU 
 
 if(ENABLE_GNURADIO_PREREQ)
     add_subdirectory(gr-limesdr)
+else()
+    add_feature_info(GNURADIO OFF "GNU Radio 3.9+ Plug-in")
 endif()
 
 ########################################################################


### PR DESCRIPTION
# Fixed
- Feature listing not showing up when GNU Radio's build pre-conditions are not met