### PR TITLE
Copy wxWidgets DLLs to the binary on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,13 +24,6 @@ option(ENABLE_NEW_GAIN_BEHAVIOUR "Enable new gain functionality" OFF)
 #include modules for finding CyAPI
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
-# It seems like VS/CMake using VS2017 or VS2019 only sets the `CMAKE_BUILD_TYPE_INIT` variable to the correct value on build
-# leaving `CMAKE_BUILD_TYPE` unset leading to the default being Release mode settings.
-# This workaround is not required with VS2022
-if(MSVC_TOOLSET_VERSION LESS 143)
-    set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_INIT})
-endif()
-
 list(FIND CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}" index)
 if(${index} EQUAL -1)
     set(CMAKE_BUILD_TYPE "Release")
@@ -145,10 +138,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
     #disable gcc caller-saves flag for O2-O3 optimizations
     #workaround fix for gcc 9.3+
-    if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-        if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.3 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 9.9)
-            add_compile_options(-fno-caller-saves)
-        endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.3 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 9.9)
+        add_compile_options($<$<NOT:$<CONFIG:Debug>>:-fno-caller-saves>)
     endif()
 
     #default SIMD configuration uses native build flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,13 @@ option(ENABLE_NEW_GAIN_BEHAVIOUR "Enable new gain functionality" OFF)
 #include modules for finding CyAPI
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
+# It seems like VS/CMake using VS2017 or VS2019 only sets the `CMAKE_BUILD_TYPE_INIT` variable to the correct value on build
+# leaving `CMAKE_BUILD_TYPE` unset leading to the default being Release mode settings.
+# This workaround is not required with VS2022
+if(MSVC_TOOLSET_VERSION LESS 143)
+    set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_INIT})
+endif()
+
 list(FIND CMAKE_CONFIGURATION_TYPES "${CMAKE_BUILD_TYPE}" index)
 if(${index} EQUAL -1)
     set(CMAKE_BUILD_TYPE "Release")

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -11,6 +11,13 @@ if(NOT wxWidgets_FOUND AND WIN32)
     cmake_policy(SET CMP0135 NEW)
     message(STATUS "Downloading wxWidgets headers.")
     set(wxRoot ${PROJECT_BINARY_DIR}/_deps/wxWidgets)
+
+    # If 2017 or 2019
+    if(MSVC_TOOLSET_VERSION LESS 143)
+        set(additional_folder "/${CMAKE_BUILD_TYPE_INIT}")
+        set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_INIT})
+    endif()
+
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         fetchcontent_declare(
             wxWidgets
@@ -25,13 +32,31 @@ if(NOT wxWidgets_FOUND AND WIN32)
             SOURCE_DIR ${wxRoot} EXCLUDE_FROM_ALL)
     endif()
 
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(wxWidgetsReleaseDLLs wxWidgetsRelease)
+
+        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+            fetchcontent_declare(
+                ${wxWidgetsReleaseDLLs}
+                URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxMSW-3.2.5_vc14x_x64_ReleaseDLL.7z
+                URL_HASH SHA1=531a679127365546022f53224806e57a5b5584ae
+                SOURCE_DIR ${wxRoot}/lib/vc14x_x64_dll/ReleaseDLLs EXCLUDE_FROM_ALL)
+        else()
+            fetchcontent_declare(
+                ${wxWidgetsReleaseDLLs}
+                URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxMSW-3.2.5_vc14x_ReleaseDLL.7z
+                URL_HASH SHA1=49029e164b653d41c72584f30b6a7ac5c4eac560
+                SOURCE_DIR ${wxRoot}/lib/vc14x_dll/ReleaseDLLs EXCLUDE_FROM_ALL)
+        endif()
+    endif()
+
     fetchcontent_declare(
         wxWidgetsHeaders
         URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxWidgets-3.2.5-headers.7z
         URL_HASH SHA1=dd01f12371f4f320dfdc4d2e53b4514eb6f296e7
         SOURCE_DIR ${wxRoot}/include EXCLUDE_FROM_ALL)
 
-    fetchcontent_makeavailable(wxWidgets wxWidgetsHeaders)
+    fetchcontent_makeavailable(wxWidgets wxWidgetsHeaders ${wxWidgetsReleaseDLLs})
 
     # find downloaded libraries
     set(wxWidgets_ROOT_DIR ${wxRoot})
@@ -106,5 +131,27 @@ if(MSVC)
         APPEND
         PROPERTY LINK_FLAGS /SUBSYSTEM:WINDOWS)
 endif(MSVC)
+
+if(WIN32)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(x64_postfix "_x64")
+    endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        set(debug_flag "d")
+    else()
+        set(release_dir "/ReleaseDLLs/lib/vc14x${x64_postfix}_dll")
+    endif()
+
+    add_custom_command(
+        TARGET ${GUI_EXECUTABLE_NAME}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different
+            ${wxWidgets_LIB_DIR}${release_dir}/wxmsw32u${debug_flag}_gl_vc14x${x64_postfix}.dll
+            ${wxWidgets_LIB_DIR}${release_dir}/wxmsw32u${debug_flag}_core_vc14x${x64_postfix}.dll
+            ${wxWidgets_LIB_DIR}${release_dir}/wxbase32u${debug_flag}_vc14x${x64_postfix}.dll
+            ${BINARY_OUTPUT_DIR}${additional_folder})
+endif(WIN32)
 
 install(TARGETS ${GUI_EXECUTABLE_NAME} DESTINATION bin)

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -12,10 +12,9 @@ if(NOT wxWidgets_FOUND AND WIN32)
     message(STATUS "Downloading wxWidgets headers.")
     set(wxRoot ${PROJECT_BINARY_DIR}/_deps/wxWidgets)
 
-    # If 2017 or 2019
+    # VS2017 and VS2019 create an additional folder for storing the binaries, we need to copy the DLLs there.
     if(MSVC_TOOLSET_VERSION LESS 143)
-        set(additional_folder "/${CMAKE_BUILD_TYPE_INIT}")
-        set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE_INIT})
+        set(additional_folder "/${CMAKE_BUILD_TYPE}")
     endif()
 
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -11,24 +11,24 @@ if(NOT wxWidgets_FOUND AND WIN32)
     cmake_policy(SET CMP0135 NEW)
     message(STATUS "Downloading wxWidgets headers.")
     set(wxRoot ${PROJECT_BINARY_DIR}/_deps/wxWidgets)
-    if(CMAKE_CL_64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         fetchcontent_declare(
             wxWidgets
-            URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.4/wxMSW-3.2.4_vc14x_x64_Dev.7z
-            URL_HASH SHA1=19cf62ade3c3fc55813ad9a2f1a49220574cb54a
+            URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxMSW-3.2.5_vc14x_x64_Dev.7z
+            URL_HASH SHA1=f5941fea2d563531401edd32f85b195be01155e9
             SOURCE_DIR ${wxRoot} EXCLUDE_FROM_ALL)
     else()
         fetchcontent_declare(
             wxWidgets
-            URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.4/wxMSW-3.2.4_vc14x_Dev.7z
-            URL_HASH SHA1=29647b24e5120b62e588827c163f0fe660936002
+            URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxMSW-3.2.5_vc14x_Dev.7z
+            URL_HASH SHA1=b5c526e3249edf8a9731e3ff36022794637668c3
             SOURCE_DIR ${wxRoot} EXCLUDE_FROM_ALL)
     endif()
 
     fetchcontent_declare(
         wxWidgetsHeaders
-        URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.4/wxWidgets-3.2.4-headers.7z
-        URL_HASH SHA1=86022483a0bfe81edf5aee38de07a0800f0a0602
+        URL https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.5/wxWidgets-3.2.5-headers.7z
+        URL_HASH SHA1=dd01f12371f4f320dfdc4d2e53b4514eb6f296e7
         SOURCE_DIR ${wxRoot}/include EXCLUDE_FROM_ALL)
 
     fetchcontent_makeavailable(wxWidgets wxWidgetsHeaders)

--- a/GUI/CMakeLists.txt
+++ b/GUI/CMakeLists.txt
@@ -12,11 +12,6 @@ if(NOT wxWidgets_FOUND AND WIN32)
     message(STATUS "Downloading wxWidgets headers.")
     set(wxRoot ${PROJECT_BINARY_DIR}/_deps/wxWidgets)
 
-    # VS2017 and VS2019 create an additional folder for storing the binaries, we need to copy the DLLs there.
-    if(MSVC_TOOLSET_VERSION LESS 143)
-        set(additional_folder "/${CMAKE_BUILD_TYPE}")
-    endif()
-
     if(CMAKE_SIZEOF_VOID_P EQUAL 8)
         fetchcontent_declare(
             wxWidgets
@@ -136,11 +131,13 @@ if(WIN32)
         set(x64_postfix "_x64")
     endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(debug_flag "d")
-    else()
-        set(release_dir "/ReleaseDLLs/lib/vc14x${x64_postfix}_dll")
+    get_cmake_property(IS_MULTI_CONF GENERATOR_IS_MULTI_CONFIG)
+    if(${IS_MULTI_CONF})
+        set(additional_folder "/$<CONFIG>")
     endif()
+
+    set(debug_flag "$<$<CONFIG:Debug>:d>")
+    set(release_dir "$<$<NOT:$<CONFIG:Debug>>:/ReleaseDLLs/lib/vc14x${x64_postfix}_dll>")
 
     add_custom_command(
         TARGET ${GUI_EXECUTABLE_NAME}


### PR DESCRIPTION
# Added
- Automatically copy over wxWidgets DLLs on Windows to the binary directory to remove the need to manually copy them.

# Changed
- Updated wxWidgets used on Windows to 3.2.5