### PR TITLE
Remove floating point calculations from LMS7002M embeded code

### DIFF
--- a/embedded/include/limesuiteng/embedded/lms7002m/lms7002m.h
+++ b/embedded/include/limesuiteng/embedded/lms7002m/lms7002m.h
@@ -56,11 +56,15 @@ typedef struct lms7002m_hooks {
     void* on_cgen_frequency_changed_userData;
 } lms7002m_hooks;
 
+struct lms7002m_decibel {
+    int32_t data;
+};
+
 struct lms7002m_context* lms7002m_create(const lms7002m_hooks* hooks);
 void lms7002m_destroy(struct lms7002m_context* context);
 
-float lms7002m_get_reference_clock(struct lms7002m_context* context);
-lime_Result lms7002m_set_reference_clock(struct lms7002m_context* context, float frequency_Hz);
+uint32_t lms7002m_get_reference_clock(struct lms7002m_context* context);
+lime_Result lms7002m_set_reference_clock(struct lms7002m_context* context, uint32_t frequency_Hz);
 
 lime_Result lms7002m_enable_channel(
     struct lms7002m_context* self, const bool isTx, const enum lms7002m_channel channel, const bool enable);
@@ -76,23 +80,29 @@ lime_Result lms7002m_tune_cgen_vco(struct lms7002m_context* self);
 lime_Result lms7002m_set_frequency_cgen(struct lms7002m_context* context, uint32_t frequency_Hz);
 uint32_t lms7002m_get_frequency_cgen(struct lms7002m_context* self);
 
-lime_Result lms7002m_set_rbbpga_db(struct lms7002m_context* self, const float value, const enum lms7002m_channel channel);
-float lms7002m_get_rbbpga_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
+lime_Result lms7002m_set_rbbpga_db(
+    struct lms7002m_context* self, const struct lms7002m_decibel value, const enum lms7002m_channel channel);
+struct lms7002m_decibel lms7002m_get_rbbpga_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
 
-lime_Result lms7002m_set_rfelna_db(struct lms7002m_context* self, const float value, const enum lms7002m_channel channel);
-float lms7002m_get_rfelna_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
+lime_Result lms7002m_set_rfelna_db(
+    struct lms7002m_context* self, const struct lms7002m_decibel value, const enum lms7002m_channel channel);
+struct lms7002m_decibel lms7002m_get_rfelna_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
 
-lime_Result lms7002m_set_rfe_loopback_lna_db(struct lms7002m_context* self, const float gain, const enum lms7002m_channel channel);
-float lms7002m_get_rfe_loopback_lna_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
+lime_Result lms7002m_set_rfe_loopback_lna_db(
+    struct lms7002m_context* self, const struct lms7002m_decibel gain, const enum lms7002m_channel channel);
+struct lms7002m_decibel lms7002m_get_rfe_loopback_lna_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
 
-lime_Result lms7002m_set_rfetia_db(struct lms7002m_context* self, const float value, const enum lms7002m_channel channel);
-float lms7002m_get_rfetia_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
+lime_Result lms7002m_set_rfetia_db(
+    struct lms7002m_context* self, const struct lms7002m_decibel value, const enum lms7002m_channel channel);
+struct lms7002m_decibel lms7002m_get_rfetia_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
 
-lime_Result lms7002m_set_trfpad_db(struct lms7002m_context* self, const float value, const enum lms7002m_channel channel);
-float lms7002m_get_trfpad_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
+lime_Result lms7002m_set_trfpad_db(
+    struct lms7002m_context* self, const struct lms7002m_decibel value, const enum lms7002m_channel channel);
+struct lms7002m_decibel lms7002m_get_trfpad_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
 
-lime_Result lms7002m_set_trf_loopback_pad_db(struct lms7002m_context* self, const float gain, const enum lms7002m_channel channel);
-float lms7002m_get_trf_loopback_pad_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
+lime_Result lms7002m_set_trf_loopback_pad_db(
+    struct lms7002m_context* self, const struct lms7002m_decibel gain, const enum lms7002m_channel channel);
+struct lms7002m_decibel lms7002m_get_trf_loopback_pad_db(struct lms7002m_context* self, const enum lms7002m_channel channel);
 
 lime_Result lms7002m_set_path_rfe(struct lms7002m_context* self, const enum lms7002m_path_rfe path);
 uint8_t lms7002m_get_path_rfe(struct lms7002m_context* self);
@@ -102,7 +112,7 @@ uint8_t lms7002m_get_band_trf(struct lms7002m_context* self);
 
 lime_Result lms7002m_set_path(struct lms7002m_context* self, bool isTx, enum lms7002m_channel channel, uint8_t path);
 
-float lms7002m_get_reference_clock_tsp(struct lms7002m_context* self, bool isTx);
+uint32_t lms7002m_get_reference_clock_tsp(struct lms7002m_context* self, bool isTx);
 bool lms7002m_get_cgen_locked(struct lms7002m_context* self);
 bool lms7002m_get_sx_locked(struct lms7002m_context* self, bool isTx);
 
@@ -111,49 +121,49 @@ lime_Result lms7002m_tune_vco(struct lms7002m_context* self, enum lms7002m_vco_t
 lime_Result lms7002m_set_frequency_sx(struct lms7002m_context* self, bool isTx, uint32_t freq_Hz);
 uint32_t lms7002m_get_frequency_sx(struct lms7002m_context* self, bool isTx);
 
-lime_Result lms7002m_set_nco_frequency(struct lms7002m_context* self, bool isTx, const uint8_t index, float freq_Hz);
-float lms7002m_get_nco_frequency(struct lms7002m_context* self, bool isTx, const uint8_t index);
+lime_Result lms7002m_set_nco_frequency(struct lms7002m_context* self, bool isTx, const uint8_t index, uint32_t freq_Hz);
+uint32_t lms7002m_get_nco_frequency(struct lms7002m_context* self, bool isTx, const uint8_t index);
 
-lime_Result lms7002m_set_nco_phase_offset(struct lms7002m_context* self, bool isTx, uint8_t index, float angle_deg);
-lime_Result lms7002m_set_nco_phase_offset_for_mode_0(struct lms7002m_context* self, bool isTx, float angle_deg);
+lime_Result lms7002m_set_nco_phase_offset(struct lms7002m_context* self, bool isTx, uint8_t index, uint16_t pho_calculated);
+lime_Result lms7002m_set_nco_phase_offset_for_mode_0(struct lms7002m_context* self, bool isTx, uint16_t pho_calculated);
 lime_Result lms7002m_set_nco_phases(
-    struct lms7002m_context* self, bool isTx, const float* const angles_deg, uint8_t count, float frequencyOffset);
+    struct lms7002m_context* self, bool isTx, const uint16_t* const angles_deg, uint8_t count, uint32_t frequencyOffset);
 
 lime_Result lms7002m_set_nco_frequencies(
-    struct lms7002m_context* self, bool isTx, const float* const freq_Hz, uint8_t count, float phaseOffset);
+    struct lms7002m_context* self, bool isTx, const uint32_t* const freq_Hz, uint8_t count, uint16_t phaseOffset);
 lime_Result lms7002m_get_nco_frequencies(
-    struct lms7002m_context* self, bool isTx, float* const freq_Hz, uint8_t count, float* phaseOffset);
+    struct lms7002m_context* self, bool isTx, uint32_t* const freq_Hz, uint8_t count, uint16_t* phaseOffset);
 
 lime_Result lms7002m_set_gfir_coefficients(
-    struct lms7002m_context* self, bool isTx, uint8_t gfirIndex, const float* const coef, uint8_t coefCount);
+    struct lms7002m_context* self, bool isTx, uint8_t gfirIndex, const uint16_t* const coef, uint8_t coefCount);
 lime_Result lms7002m_get_gfir_coefficients(
-    struct lms7002m_context* self, bool isTx, uint8_t gfirIndex, float* const coef, uint8_t coefCount);
+    struct lms7002m_context* self, bool isTx, uint8_t gfirIndex, uint16_t* const coef, uint8_t coefCount);
 
 lime_Result lms7002m_set_interface_frequency(
-    struct lms7002m_context* self, float cgen_freq_Hz, const uint8_t hbi, const uint8_t hbd);
+    struct lms7002m_context* self, uint32_t cgen_freq_Hz, const uint8_t hbi, const uint8_t hbd);
 
 lime_Result lms7002m_enable_sxtdd(struct lms7002m_context* self, bool tdd);
 
-lime_Result lms7002m_set_dc_offset(struct lms7002m_context* self, bool isTx, const float I, const float Q);
-lime_Result lms7002m_get_dc_offset(struct lms7002m_context* self, bool isTx, float* const I, float* const Q);
+lime_Result lms7002m_set_dc_offset(struct lms7002m_context* self, bool isTx, const uint8_t I, const uint8_t Q);
+lime_Result lms7002m_get_dc_offset(struct lms7002m_context* self, bool isTx, uint8_t* const I, uint8_t* const Q);
 
 lime_Result lms7002m_set_i_q_balance(
-    struct lms7002m_context* self, bool isTx, const float phase, const float gainI, const float gainQ);
+    struct lms7002m_context* self, bool isTx, const int16_t iqcorr, const uint16_t gcorri, const uint16_t gcorrq);
 lime_Result lms7002m_get_i_q_balance(
-    struct lms7002m_context* self, bool isTx, float* const phase, float* const gainI, float* const gainQ);
+    struct lms7002m_context* self, bool isTx, int16_t* const iqcorr, uint16_t* const gcorri, uint16_t* const gcorrq);
 
-float lms7002m_get_temperature(struct lms7002m_context* self);
+uint16_t lms7002m_get_temperature(struct lms7002m_context* self);
 
-lime_Result lms7002m_set_clock_frequency(struct lms7002m_context* self, enum lms7002m_clock_id clk_id, float freq);
-float lms7002m_get_clock_frequency(struct lms7002m_context* self, enum lms7002m_clock_id clk_id);
+lime_Result lms7002m_set_clock_frequency(struct lms7002m_context* self, enum lms7002m_clock_id clk_id, uint32_t freq);
+uint32_t lms7002m_get_clock_frequency(struct lms7002m_context* self, enum lms7002m_clock_id clk_id);
 
-float lms7002m_get_sample_rate(struct lms7002m_context* self, bool isTx, enum lms7002m_channel ch);
+uint32_t lms7002m_get_sample_rate(struct lms7002m_context* self, bool isTx, enum lms7002m_channel ch);
 
 lime_Result lms7002m_set_gfir_filter(
-    struct lms7002m_context* self, bool isTx, enum lms7002m_channel ch, bool enabled, float bandwidth);
+    struct lms7002m_context* self, bool isTx, enum lms7002m_channel ch, bool enabled, uint32_t bandwidth);
 
-lime_Result lms7002m_set_rx_lpf(struct lms7002m_context* self, float rfBandwidth_Hz);
-lime_Result lms7002m_set_tx_lpf(struct lms7002m_context* self, float rfBandwidth_Hz);
+lime_Result lms7002m_set_rx_lpf(struct lms7002m_context* self, uint32_t rfBandwidth_Hz);
+lime_Result lms7002m_set_tx_lpf(struct lms7002m_context* self, uint32_t rfBandwidth_Hz);
 
 int16_t lms7002m_read_analog_dc(struct lms7002m_context* self, const uint16_t addr);
 

--- a/embedded/lms7002m/lms7002m.c
+++ b/embedded/lms7002m/lms7002m.c
@@ -291,7 +291,7 @@ lime_Result lms7002m_set_frequency_cgen(lms7002m_context* self, uint32_t freq_Hz
     if (vco <= cgen_vco_min || vco >= cgen_vco_max)
     {
         return lms7002m_report_error(
-            self, lime_Result_Error, "SetFrequencyCGEN(%g MHz) - cannot deliver requested frequency", freq_Hz);
+            self, lime_Result_Error, "SetFrequencyCGEN(%u Hz) - cannot deliver requested frequency", freq_Hz);
     }
 
     const uint32_t refClk = lms7002m_get_reference_clock(self);
@@ -306,7 +306,7 @@ lime_Result lms7002m_set_frequency_cgen(lms7002m_context* self, uint32_t freq_Hz
     lms7002m_spi_modify_csr(self, LMS7002M_DIV_OUTCH_CGEN, div_outch_cgen); //DIV_OUTCH_CGEN
 
     LOG_D(self, "INT %d, FRAC %d, DIV_OUTCH_CGEN %d", integerPart, fractionalPart, div_outch_cgen);
-    LOG_D(self, "VCO %.2f MHz, RefClk %u MHz", vco, refClk);
+    LOG_D(self, "VCO %u Hz, RefClk %u Hz", vco, refClk);
 
     if (lms7002m_tune_cgen_vco(self) != lime_Result_Success)
     {
@@ -471,7 +471,7 @@ struct lms7002m_decibel lms7002m_get_rfelna_db(lms7002m_context* self, const enu
 }
 
 lime_Result lms7002m_set_rfe_loopback_lna_db(
-    lms7002m_context* self, const struct lms7002m_decibel gain, const enum lms7002m_channel channel) // TODO
+    lms7002m_context* self, const struct lms7002m_decibel gain, const enum lms7002m_channel channel)
 {
     enum lms7002m_channel savedChannel = lms7002m_set_active_channel_readback(self, channel);
 
@@ -628,7 +628,7 @@ struct lms7002m_decibel lms7002m_get_trfpad_db(lms7002m_context* self, const enu
 }
 
 lime_Result lms7002m_set_trf_loopback_pad_db(
-    lms7002m_context* self, const struct lms7002m_decibel gain, const enum lms7002m_channel channel) // TODO
+    lms7002m_context* self, const struct lms7002m_decibel gain, const enum lms7002m_channel channel)
 {
     enum lms7002m_channel savedChannel = lms7002m_set_active_channel_readback(self, channel);
 
@@ -646,7 +646,7 @@ lime_Result lms7002m_set_trf_loopback_pad_db(
     return ret;
 }
 
-struct lms7002m_decibel lms7002m_get_trf_loopback_pad_db(lms7002m_context* self, const enum lms7002m_channel channel) // TODO
+struct lms7002m_decibel lms7002m_get_trf_loopback_pad_db(lms7002m_context* self, const enum lms7002m_channel channel)
 {
     enum lms7002m_channel savedChannel = lms7002m_set_active_channel_readback(self, channel);
 
@@ -982,7 +982,7 @@ static lime_Result lms7002m_write_sx_registers(
     lms7002m_spi_modify_csr(self, LMS7002M_EN_DIV2_DIVPROG, (VCOfreq_hz > m_dThrF)); //EN_DIV2_DIVPROG
 
     LOG_D(self,
-        "SX VCO:%.3f MHz, RefClk:%.3f MHz, INT:%d, FRAC:%d, DIV_LOCH:%d, EN_DIV2_DIVPROG:%d",
+        "SX VCO:% Hz, RefClk:%u Hz, INT:%u, FRAC:%u, DIV_LOCH:%u, EN_DIV2_DIVPROG:%d",
         VCOfreq_hz,
         reference_clock_hz,
         integerPart,
@@ -995,7 +995,7 @@ static lime_Result lms7002m_write_sx_registers(
 
 lime_Result lms7002m_set_frequency_sx(lms7002m_context* self, bool isTx, uint32_t LO_freq_hz)
 {
-    LOG_D(self, "Set %s LO frequency (%g MHz)", isTx ? "Tx" : "Rx", LO_freq_hz);
+    LOG_D(self, "Set %s LO frequency (%u Hz)", isTx ? "Tx" : "Rx", LO_freq_hz);
 
     if (LO_freq_hz < 0)
         return lime_Result_InvalidValue;
@@ -1036,7 +1036,7 @@ lime_Result lms7002m_set_frequency_sx(lms7002m_context* self, bool isTx, uint32_
     {
         return lms7002m_report_error(self,
             lime_Result_OutOfRange,
-            "SetFrequencySX%s(%g MHz) - required VCO frequencies are out of range [%g-%g] MHz",
+            "SetFrequencySX%s(%u Hz) - required VCO frequencies are out of range [%g-%g] Hz",
             isTx ? "T" : "R",
             LO_freq_hz,
             VCO_min_frequency[0],
@@ -1108,7 +1108,7 @@ lime_Result lms7002m_set_frequency_sx(lms7002m_context* self, bool isTx, uint32_
 
     if (canDeliverFrequency == false)
         return lms7002m_report_error(
-            self, lime_Result_Error, "SetFrequencySX%s(%g MHz) - cannot deliver frequency", isTx ? "T" : "R", LO_freq_hz);
+            self, lime_Result_Error, "SetFrequencySX%s(%u Hz) - cannot deliver frequency", isTx ? "T" : "R", LO_freq_hz);
     return lime_Result_Success;
 }
 

--- a/embedded/lms7002m/lms7002m_context.h
+++ b/embedded/lms7002m/lms7002m_context.h
@@ -6,7 +6,7 @@
 typedef struct lms7002m_context {
     lms7002m_hooks hooks;
 
-    float reference_clock_hz; ///< Common reference clock for CGEN, SXR, SXT
+    uint32_t reference_clock_hz; ///< Common reference clock for CGEN, SXR, SXT
 } lms7002m_context;
 
 #endif // LIME_LMS7002M_CONTEXT_H

--- a/embedded/lms7002m/privates.c
+++ b/embedded/lms7002m/privates.c
@@ -106,7 +106,7 @@ uint16_t lms7002m_spi_read_csr(lms7002m_context* self, const lms7002m_csr csr)
     return lms7002m_spi_read_bits(self, csr.address, csr.msb, csr.lsb);
 }
 
-int16_t clamp_int(int16_t value, int16_t min, int16_t max)
+int32_t clamp_int(int32_t value, int32_t min, int32_t max)
 {
     if (value < min)
         return min;
@@ -115,16 +115,7 @@ int16_t clamp_int(int16_t value, int16_t min, int16_t max)
     return value;
 }
 
-uint16_t clamp_uint(uint16_t value, uint16_t min, uint16_t max)
-{
-    if (value < min)
-        return min;
-    if (value > max)
-        return max;
-    return value;
-}
-
-float clamp_float(float value, float min, float max)
+uint32_t clamp_uint(uint32_t value, uint32_t min, uint32_t max)
 {
     if (value < min)
         return min;

--- a/embedded/lms7002m/privates.h
+++ b/embedded/lms7002m/privates.h
@@ -34,8 +34,7 @@ void lms7002m_save_chip_state(struct lms7002m_context* self, bool wr);
 void lms7002m_flip_rising_edge(struct lms7002m_context* self, const lms7002m_csr* reg);
 
 // clamps
-int16_t clamp_int(int16_t value, int16_t min, int16_t max);
-uint16_t clamp_uint(uint16_t value, uint16_t min, uint16_t max);
-float clamp_float(float value, float min, float max);
+int32_t clamp_int(int32_t value, int32_t min, int32_t max);
+uint32_t clamp_uint(uint32_t value, uint32_t min, uint32_t max);
 
 #endif // LMS7002M_PRIVATES_H

--- a/src/boards/LMS7002M_SDRDevice.cpp
+++ b/src/boards/LMS7002M_SDRDevice.cpp
@@ -1139,10 +1139,25 @@ OpStatus LMS7002M_SDRDevice::LMS7002ChannelCalibration(LMS7002M& chip, const Cha
     const ChannelConfig& ch = config;
 
     // TODO: Don't configure GFIR when external ADC/DAC is used
-    if (ch.rx.enabled && chip.SetGFIRFilter(TRXDir::Rx, enumChannel, ch.rx.gfir.enabled, ch.rx.gfir.bandwidth) != OpStatus::Success)
-        return lime::ReportError(OpStatus::Error, "Rx ch%i GFIR config failed", i);
-    if (ch.tx.enabled && chip.SetGFIRFilter(TRXDir::Tx, enumChannel, ch.tx.gfir.enabled, ch.tx.gfir.bandwidth) != OpStatus::Success)
-        return lime::ReportError(OpStatus::Error, "Tx ch%i GFIR config failed", i);
+    if (ch.rx.enabled)
+    {
+        OpStatus status = chip.SetGFIRFilter(TRXDir::Rx, enumChannel, ch.rx.gfir.enabled, ch.rx.gfir.bandwidth);
+
+        if (status == OpStatus::NotImplemented)
+            lime::warning("Rx ch%i GFIR config not implemented", i);
+        else if (status != OpStatus::Success)
+            return lime::ReportError(OpStatus::Error, "Rx ch%i GFIR config failed", i);
+    }
+
+    if (ch.tx.enabled)
+    {
+        OpStatus status = chip.SetGFIRFilter(TRXDir::Tx, enumChannel, ch.tx.gfir.enabled, ch.tx.gfir.bandwidth);
+
+        if (status == OpStatus::NotImplemented)
+            lime::warning("Tx ch%i GFIR config not implemented", i);
+        else if (status != OpStatus::Success)
+            return lime::ReportError(OpStatus::Error, "Tx ch%i GFIR config failed", i);
+    }
 
     OpStatus rxStatus = OpStatus::Success;
     if (ch.rx.calibrate && ch.rx.enabled)

--- a/src/boards/LimeSDR_X3/LimeSDR_X3.cpp
+++ b/src/boards/LimeSDR_X3/LimeSDR_X3.cpp
@@ -657,12 +657,15 @@ void LimeSDR_X3::ConfigureDirection(TRXDir dir, LMS7002M& chip, const SDRConfig&
 
     if (socIndex == 0)
     {
-        if (trx.enabled && chip.SetGFIRFilter(dir,
-                               ch == 0 ? LMS7002M::Channel::ChA : LMS7002M::Channel::ChB,
-                               trx.gfir.enabled,
-                               trx.gfir.bandwidth) != OpStatus::Success)
+        if (trx.enabled)
         {
-            throw std::logic_error(strFormat("%s ch%i GFIR config failed", ToString(dir).c_str(), ch));
+            OpStatus status = chip.SetGFIRFilter(
+                dir, ch == 0 ? LMS7002M::Channel::ChA : LMS7002M::Channel::ChB, trx.gfir.enabled, trx.gfir.bandwidth);
+
+            if (status == OpStatus::NotImplemented)
+                lime::warning("%s ch%i GFIR config not implemented", ToString(dir).c_str(), ch);
+            else if (status != OpStatus::Success)
+                throw std::logic_error(strFormat("%s ch%i GFIR config failed", ToString(dir).c_str(), ch));
         }
     }
 

--- a/src/chips/LMS7002M/LMS7002M.cpp
+++ b/src/chips/LMS7002M/LMS7002M.cpp
@@ -29,6 +29,10 @@
     #pragma GCC diagnostic pop
 #endif
 
+#ifndef M_PI
+    #define M_PI 3.14159265358979323846 /* pi */
+#endif
+
 #include "limesuiteng/types.h"
 #include "comms/ISPI.h"
 #include "LMS7002M_RegistersMap.h"
@@ -143,6 +147,34 @@ static_assert(LMS7002M::PathRFE::LB2 == static_cast<LMS7002M::PathRFE>(LMS7002M_
 static_assert(LMS7002M::VCO_Module::VCO_CGEN == static_cast<LMS7002M::VCO_Module>(LMS7002M_VCO_CGEN));
 static_assert(LMS7002M::VCO_Module::VCO_SXR == static_cast<LMS7002M::VCO_Module>(LMS7002M_VCO_SXR));
 static_assert(LMS7002M::VCO_Module::VCO_SXT == static_cast<LMS7002M::VCO_Module>(LMS7002M_VCO_SXT));
+
+struct Decibel : public lms7002m_decibel {
+    Decibel(const float& f);
+    Decibel(const lms7002m_decibel& f);
+    Decibel& operator=(const float& other);
+    operator float() const;
+};
+
+Decibel::Decibel(const float& f)
+{
+    data = f * 65536;
+}
+
+Decibel::Decibel(const lms7002m_decibel& f)
+{
+    data = f.data;
+}
+
+Decibel& Decibel::operator=(const float& other)
+{
+    data = other * 65536;
+    return *this;
+}
+
+Decibel::operator float() const
+{
+    return data / 65536;
+}
 
 /** @brief Sets connection which is used for data communication with chip
 */
@@ -713,68 +745,70 @@ OpStatus LMS7002M::SaveConfig(const std::string& filename)
 
 OpStatus LMS7002M::SetRBBPGA_dB(const float_type value, const Channel channel)
 {
-    lime_Result result = lms7002m_set_rbbpga_db(mC_impl, value, static_cast<lms7002m_channel>(channel));
+    lime_Result result = lms7002m_set_rbbpga_db(mC_impl, static_cast<Decibel>(value), static_cast<lms7002m_channel>(channel));
     return ResultToStatus(result);
 }
 
 float_type LMS7002M::GetRBBPGA_dB(const Channel channel)
 {
-    return lms7002m_get_rbbpga_db(mC_impl, static_cast<lms7002m_channel>(channel));
+    return static_cast<Decibel>(lms7002m_get_rbbpga_db(mC_impl, static_cast<lms7002m_channel>(channel)));
 }
 
 OpStatus LMS7002M::SetRFELNA_dB(const float_type value, const Channel channel)
 {
-    lime_Result result = lms7002m_set_rfelna_db(mC_impl, value, static_cast<lms7002m_channel>(channel));
+    lime_Result result = lms7002m_set_rfelna_db(mC_impl, static_cast<Decibel>(value), static_cast<lms7002m_channel>(channel));
     return ResultToStatus(result);
 }
 
 float_type LMS7002M::GetRFELNA_dB(const Channel channel)
 {
-    return lms7002m_get_rfelna_db(mC_impl, static_cast<lms7002m_channel>(channel));
+    return static_cast<Decibel>(lms7002m_get_rfelna_db(mC_impl, static_cast<lms7002m_channel>(channel)));
 }
 
 OpStatus LMS7002M::SetRFELoopbackLNA_dB(const float_type gain, const Channel channel)
 {
-    lime_Result result = lms7002m_set_rfe_loopback_lna_db(mC_impl, gain, static_cast<lms7002m_channel>(channel));
+    lime_Result result =
+        lms7002m_set_rfe_loopback_lna_db(mC_impl, static_cast<Decibel>(gain), static_cast<lms7002m_channel>(channel));
     return ResultToStatus(result);
 }
 
 float_type LMS7002M::GetRFELoopbackLNA_dB(const Channel channel)
 {
-    return lms7002m_get_rfe_loopback_lna_db(mC_impl, static_cast<lms7002m_channel>(channel));
+    return static_cast<Decibel>(lms7002m_get_rfe_loopback_lna_db(mC_impl, static_cast<lms7002m_channel>(channel)));
 }
 
 OpStatus LMS7002M::SetRFETIA_dB(const float_type value, const Channel channel)
 {
-    lime_Result result = lms7002m_set_rfetia_db(mC_impl, value, static_cast<lms7002m_channel>(channel));
+    lime_Result result = lms7002m_set_rfetia_db(mC_impl, static_cast<Decibel>(value), static_cast<lms7002m_channel>(channel));
     return ResultToStatus(result);
 }
 
 float_type LMS7002M::GetRFETIA_dB(const Channel channel)
 {
-    return lms7002m_get_rfetia_db(mC_impl, static_cast<lms7002m_channel>(channel));
+    return static_cast<Decibel>(lms7002m_get_rfetia_db(mC_impl, static_cast<lms7002m_channel>(channel)));
 }
 
 OpStatus LMS7002M::SetTRFPAD_dB(const float_type value, const Channel channel)
 {
-    lime_Result result = lms7002m_set_trfpad_db(mC_impl, value, static_cast<lms7002m_channel>(channel));
+    lime_Result result = lms7002m_set_trfpad_db(mC_impl, static_cast<Decibel>(value), static_cast<lms7002m_channel>(channel));
     return ResultToStatus(result);
 }
 
 float_type LMS7002M::GetTRFPAD_dB(const Channel channel)
 {
-    return lms7002m_get_trfpad_db(mC_impl, static_cast<lms7002m_channel>(channel));
+    return static_cast<Decibel>(lms7002m_get_trfpad_db(mC_impl, static_cast<lms7002m_channel>(channel)));
 }
 
 OpStatus LMS7002M::SetTRFLoopbackPAD_dB(const float_type gain, const Channel channel)
 {
-    lime_Result result = lms7002m_set_trf_loopback_pad_db(mC_impl, gain, static_cast<lms7002m_channel>(channel));
+    lime_Result result =
+        lms7002m_set_trf_loopback_pad_db(mC_impl, static_cast<Decibel>(gain), static_cast<lms7002m_channel>(channel));
     return ResultToStatus(result);
 }
 
 float_type LMS7002M::GetTRFLoopbackPAD_dB(const Channel channel)
 {
-    return lms7002m_get_trf_loopback_pad_db(mC_impl, static_cast<lms7002m_channel>(channel));
+    return static_cast<Decibel>(lms7002m_get_trf_loopback_pad_db(mC_impl, static_cast<lms7002m_channel>(channel)));
 }
 
 // opt_gain_tbb
@@ -857,32 +891,33 @@ float_type LMS7002M::GetReferenceClk_SX(TRXDir dir)
 
 OpStatus LMS7002M::SetNCOFrequencies(TRXDir dir, const float_type* freq_Hz, uint8_t count, float_type phaseOffset)
 {
-    std::vector<float> converted(count);
+    std::vector<uint32_t> converted(count);
     for (uint8_t i = 0; i < count; ++i)
     {
         converted.at(i) = freq_Hz[i];
     }
 
-    lime_Result result = lms7002m_set_nco_frequencies(mC_impl, dir == TRXDir::Tx, converted.data(), count, phaseOffset);
+    const uint16_t pho = 65536 * (phaseOffset / 360);
+    lime_Result result = lms7002m_set_nco_frequencies(mC_impl, dir == TRXDir::Tx, converted.data(), count, pho);
     return ResultToStatus(result);
 }
 
 std::vector<float_type> LMS7002M::GetNCOFrequencies(TRXDir dir, float_type* phaseOffset)
 {
-    std::vector<float> ncosFloat(16);
+    std::vector<uint32_t> ncosHZ(16);
 
-    float phaseOffsetFloat = 0.0;
-    lms7002m_get_nco_frequencies(mC_impl, dir == TRXDir::Tx, ncosFloat.data(), ncosFloat.size(), &phaseOffsetFloat);
+    uint16_t phaseOffsetUint16 = 0;
+    lms7002m_get_nco_frequencies(mC_impl, dir == TRXDir::Tx, ncosHZ.data(), ncosHZ.size(), &phaseOffsetUint16);
 
     std::vector<float_type> ncosDouble(16);
-    for (std::size_t i = 0; i < ncosFloat.size(); ++i)
+    for (std::size_t i = 0; i < ncosHZ.size(); ++i)
     {
-        ncosDouble.at(i) = ncosFloat.at(i);
+        ncosDouble.at(i) = ncosHZ.at(i);
     }
 
     if (phaseOffset != nullptr)
     {
-        *phaseOffset = phaseOffsetFloat;
+        *phaseOffset = 360.0 * phaseOffsetUint16 / 65536.0;
     }
 
     return ncosDouble;
@@ -1065,22 +1100,24 @@ float_type LMS7002M::GetNCOFrequency(TRXDir dir, uint8_t index, bool fromChip)
 
 OpStatus LMS7002M::SetNCOPhaseOffsetForMode0(TRXDir dir, float_type angle_deg)
 {
-    lime_Result result = lms7002m_set_nco_phase_offset_for_mode_0(mC_impl, dir == TRXDir::Tx, angle_deg);
+    const uint16_t pho = 65536 * (angle_deg / 360);
+    lime_Result result = lms7002m_set_nco_phase_offset_for_mode_0(mC_impl, dir == TRXDir::Tx, pho);
     return ResultToStatus(result);
 }
 
 OpStatus LMS7002M::SetNCOPhaseOffset(TRXDir dir, uint8_t index, float_type angle_deg)
 {
-    lime_Result result = lms7002m_set_nco_phase_offset(mC_impl, dir == TRXDir::Tx, index, angle_deg);
+    const uint16_t pho = 65536 * (angle_deg / 360);
+    lime_Result result = lms7002m_set_nco_phase_offset(mC_impl, dir == TRXDir::Tx, index, pho);
     return ResultToStatus(result);
 }
 
 OpStatus LMS7002M::SetNCOPhases(TRXDir dir, const float_type* angles_deg, uint8_t count, float_type frequencyOffset)
 {
-    std::vector<float> converted(count);
+    std::vector<uint16_t> converted(count);
     for (uint8_t i = 0; i < count; ++i)
     {
-        converted.at(i) = angles_deg[i];
+        converted.at(i) = 65536 * (angles_deg[i] / 360);
     }
 
     lime_Result result = lms7002m_set_nco_phases(mC_impl, dir == TRXDir::Tx, converted.data(), count, frequencyOffset);
@@ -1095,10 +1132,15 @@ std::vector<float_type> LMS7002M::GetNCOPhases(TRXDir dir, float_type* frequency
 
 OpStatus LMS7002M::SetGFIRCoefficients(TRXDir dir, uint8_t gfirIndex, const float_type* coef, uint8_t coefCount)
 {
-    std::vector<float> converted(coefCount);
+    std::vector<uint16_t> converted(coefCount);
     for (uint8_t i = 0; i < coefCount; ++i)
     {
-        converted.at(i) = coef[i];
+        if (coef[i] < -1 || coef[i] > 1)
+        {
+            lime::warning("Coefficient %f is outside of range [-1:1], incorrect value will be written.", coef[i]);
+        }
+
+        converted.at(i) = coef[i] * 32767;
     }
 
     lime_Result result = lms7002m_set_gfir_coefficients(mC_impl, dir == TRXDir::Tx, gfirIndex, converted.data(), coefCount);
@@ -1107,12 +1149,12 @@ OpStatus LMS7002M::SetGFIRCoefficients(TRXDir dir, uint8_t gfirIndex, const floa
 
 OpStatus LMS7002M::GetGFIRCoefficients(TRXDir dir, uint8_t gfirIndex, float_type* coef, uint8_t coefCount)
 {
-    std::vector<float> converted(coefCount);
+    std::vector<uint16_t> converted(coefCount);
 
     lime_Result result = lms7002m_get_gfir_coefficients(mC_impl, dir == TRXDir::Tx, gfirIndex, converted.data(), coefCount);
     for (uint8_t i = 0; i < coefCount; ++i)
     {
-        coef[i] = converted.at(i);
+        coef[i] = static_cast<int16_t>(converted.at(i)) / 32768.0;
     }
 
     return ResultToStatus(result);
@@ -1718,35 +1760,66 @@ OpStatus LMS7002M::EnableSXTDD(bool tdd)
 
 OpStatus LMS7002M::SetDCOffset(TRXDir dir, const float_type I, const float_type Q)
 {
-    lime_Result result = lms7002m_set_dc_offset(mC_impl, dir == TRXDir::Tx, I, Q);
+    const bool isTx = dir == TRXDir::Tx;
+    uint8_t translatedI;
+    uint8_t translatedQ;
+
+    if (isTx)
+    {
+        translatedI = lrint(I * 127);
+        translatedQ = lrint(Q * 127);
+    }
+    else
+    {
+        translatedI = lrint(fabs(I * 63)) + (I < 0 ? 64 : 0);
+        translatedQ = lrint(fabs(Q * 63)) + (Q < 0 ? 64 : 0);
+    }
+
+    lime_Result result = lms7002m_set_dc_offset(mC_impl, isTx, translatedI, translatedQ);
     return ResultToStatus(result);
 }
 
 OpStatus LMS7002M::GetDCOffset(TRXDir dir, float_type& I, float_type& Q)
 {
-    float Ifloat = 0.0;
-    float Qfloat = 0.0;
-    lime_Result result = lms7002m_get_dc_offset(mC_impl, dir == TRXDir::Tx, &Ifloat, &Qfloat);
-    I = Ifloat;
-    Q = Qfloat;
+    const bool isTx = dir == TRXDir::Tx;
+    uint8_t Iuint8 = 0;
+    uint8_t Quint8 = 0;
+    lime_Result result = lms7002m_get_dc_offset(mC_impl, isTx, &Iuint8, &Quint8);
+    if (isTx)
+    {
+        I = static_cast<int8_t>(Iuint8) / 127.0; //signed 8-bit
+        Q = static_cast<int8_t>(Quint8) / 127.0; //signed 8-bit
+    }
+    else
+    {
+        I = ((Iuint8 & 0x40) ? -1.0 : 1.0) * (Iuint8 & 0x3F) / 63.0;
+        Q = ((Quint8 & 0x40) ? -1.0 : 1.0) * (Quint8 & 0x3F) / 63.0;
+    }
+
     return ResultToStatus(result);
 }
 
 OpStatus LMS7002M::SetIQBalance(const TRXDir dir, const float_type phase, const float_type gainI, const float_type gainQ)
 {
-    lime_Result result = lms7002m_set_i_q_balance(mC_impl, dir == TRXDir::Tx, phase, gainI, gainQ);
+    const int iqcorr = lrint(2047 * (phase / (M_PI / 2)));
+    const int gcorri = lrint(2047 * gainI);
+    const int gcorrq = lrint(2047 * gainQ);
+    lime_Result result = lms7002m_set_i_q_balance(mC_impl, dir == TRXDir::Tx, iqcorr, gcorri, gcorrq);
     return ResultToStatus(result);
 }
 
 OpStatus LMS7002M::GetIQBalance(const TRXDir dir, float_type& phase, float_type& gainI, float_type& gainQ)
 {
-    float phaseFloat = 0.0;
-    float gainIFloat = 0.0;
-    float gainQFloat = 0.0;
-    lime_Result result = lms7002m_get_i_q_balance(mC_impl, dir == TRXDir::Tx, &phaseFloat, &gainIFloat, &gainQFloat);
-    phase = phaseFloat;
-    gainI = gainIFloat;
-    gainQ = gainQFloat;
+    const bool isTx = dir == TRXDir::Tx;
+    int16_t phaseInt16 = 0;
+    uint16_t gainIUint16 = 0;
+    uint16_t gainQUint16 = 0;
+    lime_Result result = lms7002m_get_i_q_balance(mC_impl, isTx, &phaseInt16, &gainIUint16, &gainQUint16);
+
+    phase = (M_PI / 2) * phaseInt16 / 2047.0;
+    gainI = gainIUint16 / 2047.0;
+    gainQ = gainQUint16 / 2047.0;
+
     return ResultToStatus(result);
 }
 
@@ -1774,7 +1847,15 @@ OpStatus LMS7002M::CalibrateRP_BIAS()
 
 float_type LMS7002M::GetTemperature()
 {
-    return lms7002m_get_temperature(mC_impl);
+    uint16_t tempUint16 = lms7002m_get_temperature(mC_impl);
+    const float Vtemp = ((tempUint16 >> 8) & 0xFF) * 1.84;
+    const float Vptat = (tempUint16 & 0xFF) * 1.84;
+    const float Vdiff = (Vptat - Vtemp) / 1.05;
+    const float temperature = 45.0 + Vdiff;
+    lime::debug(
+        "Vtemp 0x%04X, Vptat 0x%04X, Vdiff = %.2f, temp= %.3f", (tempUint16 >> 8) & 0xFF, tempUint16 & 0xFF, Vdiff, temperature);
+
+    return temperature;
 }
 
 OpStatus LMS7002M::CopyChannelRegisters(const Channel src, const Channel dest, const bool copySX)


### PR DESCRIPTION
- Convert floating point calculations to whole number calculations
- Remove any reference of floating numbers to compile on systems without floating point support
- Add `lms7002m_decibel` and `Decibel` structure to pass fixed point representation of decibel units
- Disable GFIRFilter setup for now. It does lot of floating point calculation. Later on we will come up with solution how to approach this issue
- Extract some calculation from C to C++ side. This is better solution than creating extra structures for one time use

I've tested functionality against result before changes. Most of the functions are identical precision. The ones that changed were deviations by 1 caused by precision differences.