### PR TITLE
Fix GNUPlotPipe crash on macOS when gnuplot is installed

### DIFF
--- a/src/gnuPlotPipe.h
+++ b/src/gnuPlotPipe.h
@@ -12,7 +12,12 @@ class GNUPlotPipe
     /// @param persistent Whether the pipe is persistent or not.
     GNUPlotPipe(bool persistent = true)
     {
-#ifdef __unix__
+#if defined(__APPLE__)
+        if (persistent)
+            pipeHandle = popen("gnuplot -persistent -noraise", "w");
+        else
+            pipeHandle = popen("gnuplot -noraise", "w");
+#elif defined(__unix__)
         if (persistent)
             pipeHandle = popen("gnuplot -persistent -noraise", "we");
         else


### PR DESCRIPTION
Not all versions of popen() support specifying FD_CLOEXEC as part of the mode passed to popen(). This includes popen() function on macOS. Wehn passing unsupported "e" flag to popen() it returns nullptr, leading to a crash later when writing data to gnuplot.

This change makes it so gnuplot pipe is open for write, without FD_CLOEXEC on macOS, solving the crash. It follows similar idea of Windows, which does not fcntl() to set FD_CLOEXEC.

Similar fix might be needed for other BSD systems, but it would need to be verified on an actual system.