### PR TITLE
Fix ChB overriding ChA TRF/RFE registers

### DIFF
--- a/src/boards/LimeSDR_XTRX/LimeSDR_XTRX.cpp
+++ b/src/boards/LimeSDR_XTRX/LimeSDR_XTRX.cpp
@@ -447,6 +447,11 @@ void LimeSDR_XTRX::LMS1SetPath(bool tx, uint8_t chan, uint8_t pathId)
     uint16_t sw_val = mFPGA->ReadRegister(sw_addr);
     auto& lms = mLMSChips.at(0);
 
+    // Set active channel for configuring TRF and RFE registers to match the
+    // requested channel index.
+    const LMS7002M::Channel old_channel = lms->GetActiveChannel();
+    lms->SetActiveChannel(chan == 0 ? LMS7002M::Channel::ChA : LMS7002M::Channel::ChB);
+
     if (tx)
     {
         uint8_t path;
@@ -494,6 +499,8 @@ void LimeSDR_XTRX::LMS1SetPath(bool tx, uint8_t chan, uint8_t pathId)
     // RF switch controls are toggled for both channels, use channel 0 as the deciding source.
     if (chan == 0)
         mFPGA->WriteRegister(sw_addr, sw_val);
+
+    lms->SetActiveChannel(old_channel);
 }
 
 OpStatus LimeSDR_XTRX::CustomParameterWrite(const std::vector<CustomParameterIO>& parameters)


### PR DESCRIPTION
This change fixes XTRX device configuration from using ChB RX/TX path to write to ChA LMS7002M registers.

In practice this fixes an issue of basicRX not receiving samples from the antenna until configuration of channel[1] is matched to channel[0]. Similarly, it fixes missing signal on ChA when running basicTX until channel[1] is matched to channel[0] as well.

The issue was caused by a state within which LMS1SetPath() is called, and how it interacts with LMS7002M:
- It might be called with current active channel in MAC set to ChA when is called for chan=1.
- It does explicitly set active channel when setting the TRF and RFE registers.

This change makes it so LMS1SetPath() explicitly sets channel (MAC) it will write registers for, similarly to how Calibrate() or the LMS7002M::SetPath() does it. The possible downside of this is extra time spent in registers configuration to set up the active channel, but it is unclear whether it really a problem in practice.

It is possible to avoid extra registers configuration by wiring to the TRF/RFE of both channels (Channel::ChAB). This seems to be a bit deeper change, so it is left for future development.

Test configurations:

- Attach a test signal to RxA, run basicRX (ensuring the signal does not overload the LMS7002M).

  Without this change peak amplitude is somewhere in the odds of -80 dBFS, at the LO frequency. With this change the peak is properly calculated at the test signal frequency.

  During development of this patch the basicRX was modified to have LO of 100 MHz due to limitations of the available RF generator. It is not expected that this has a significance on the results of the test.

- Attach TxA to a spectrum analyzer (via proper attenuators, to bring the signal to the analyzer's safe span).

  Without this change running basicTX does not result in any signal appearing on the signal analyzer. With this change a peak at 2Ghz is visible on the spectrum analyzer.

- Additional tests have been performed to make sure TxB and RxB work properly by slightly modifying the basicTX and basicRX applications to use those channels.