### PR TITLE
Fix potential dead-lock when starting Tx stream

### DIFF
--- a/src/protocols/TRXLooper.cpp
+++ b/src/protocols/TRXLooper.cpp
@@ -770,7 +770,10 @@ OpStatus TRXLooper::TxSetup()
 
 void TRXLooper::TxWorkLoop()
 {
+    // signal that thread is ready for work
     mTx.stage.store(Stream::ReadyStage::WorkerReady, std::memory_order_relaxed);
+    mTx.cv.notify_all();
+
     while (!mTx.terminateWorker.load(std::memory_order_relaxed))
     {
         // thread ready for work, just wait for stream enable


### PR DESCRIPTION
It is possible that the TxSetup() starts to wait on the condition variable before the worker thread store the WorkerReady stage. In this case the TxSetup() waits for the worker to be ready, and the worker thread waits for the stream enable.

The solution is to notify the condition variable after the worker thread becomes ready. This is how the Rx worker thread is done. The slight difference is that the Rx worker locks the mutex before notifying the condition variable, and the Tx worker does not. It is not required for the notifying thread to hold the lock as per standard, and the Tx worker does not acquire the lock when it notifies after transmission.

It is possible to align the Tx and Rx worker loops and avoid the unnecessary locks, but doing so is not considered part of this PR.

This was tested by running basicTX examples and LimeSDR Mini v2 SDR, Before this fix it would lock quite often in device->StreamSetup(), and after this fix it works as expected.

Surprisingly the issue did not manifest itself on XTRX, but it might just be due to a different timing on different environment. To be sure, the fix has been verified and the LimeSDR XTRX works correctly with the basicTX.