### PR TITLE
Support dkms when it is not in PATH

### DIFF
--- a/src/comms/PCIe/linux-kernel-module/CMakeLists.txt
+++ b/src/comms/PCIe/linux-kernel-module/CMakeLists.txt
@@ -84,13 +84,13 @@ endif()
 
 find_program(DKMS_EXECUTABLE NAMES dkms)
 if(NOT DKMS_EXECUTABLE)
-  set(IS_DKMS_NOT_PRESENT True)
+    set(IS_DKMS_NOT_PRESENT True)
 else()
-  # 0 means success, so it's inverted
-  execute_process(
-      COMMAND ${DKMS_EXECUTABLE} --version
-      RESULT_VARIABLE IS_DKMS_NOT_PRESENT
-      OUTPUT_QUIET)
+    # 0 means success, so it's inverted
+    execute_process(
+        COMMAND ${DKMS_EXECUTABLE} --version
+        RESULT_VARIABLE IS_DKMS_NOT_PRESENT
+        OUTPUT_QUIET)
 endif()
 
 cmake_dependent_option(USE_DKMS "Use DKMS when installing the kernel module" ON "NOT IS_DKMS_NOT_PRESENT" OFF)

--- a/src/comms/PCIe/linux-kernel-module/CMakeLists.txt
+++ b/src/comms/PCIe/linux-kernel-module/CMakeLists.txt
@@ -82,11 +82,16 @@ if(NOT INSTALL_KERNEL_MODULE)
     return()
 endif()
 
-# 0 means success, so it's inverted
-execute_process(
-    COMMAND dkms --version
-    RESULT_VARIABLE IS_DKMS_NOT_PRESENT
-    OUTPUT_QUIET)
+find_program(DKMS_EXECUTABLE NAMES dkms)
+if(NOT DKMS_EXECUTABLE)
+  set(IS_DKMS_NOT_PRESENT True)
+else()
+  # 0 means success, so it's inverted
+  execute_process(
+      COMMAND ${DKMS_EXECUTABLE} --version
+      RESULT_VARIABLE IS_DKMS_NOT_PRESENT
+      OUTPUT_QUIET)
+endif()
 
 cmake_dependent_option(USE_DKMS "Use DKMS when installing the kernel module" ON "NOT IS_DKMS_NOT_PRESENT" OFF)
 add_feature_info(DKMS USE_DKMS "DKMS support for lime PCIe kernel module")


### PR DESCRIPTION
This change allows CMake configuration to detect that dkms command is not in the current PATH. This happens on some Linux systems which do no add /usr/sbin to all users, even if they are part of sudo/wheel. For example, this is default Raspbian OS onfiguration.

CMake's find_program() allows to detect dkms command when it is in /usr/sbin but not in the current PATH.

The code block which runs dkms command is still kept, so that if the dkms is uninstalled, CMake configuration adopts to it. It could be removed in the future, but for now the idea was to minimize impact this change is bringing.