### PR TITLE
Expand command line arguments of basicRX and basicTX

### DIFF
--- a/cli/common.cpp
+++ b/cli/common.cpp
@@ -94,3 +94,19 @@ SDRDevice* ConnectToFilteredOrDefaultDevice(const std::string_view argument)
     }
     return device;
 }
+
+int AntennaNameToIndex(const std::vector<std::string>& antennaNames, const std::string& name)
+{
+    if (name.empty())
+        return -1;
+
+    for (size_t j = 0; j < antennaNames.size(); ++j)
+    {
+        if (antennaNames[j] == name)
+            return j;
+    }
+    std::cerr << "Antenna "sv << name << " not found. Available:"sv << std::endl;
+    for (const auto& iter : antennaNames)
+        std::cerr << "\t\""sv << iter << "\""sv << std::endl;
+    return -1;
+}

--- a/cli/common.h
+++ b/cli/common.h
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <algorithm>
 #include <signal.h>
+#include <string>
 #include <string_view>
 
 #include "limesuiteng/DeviceHandle.h"
@@ -19,5 +20,7 @@
 #include "limesuiteng/Logger.h"
 
 lime::SDRDevice* ConnectToFilteredOrDefaultDevice(const std::string_view argument);
+
+int AntennaNameToIndex(const std::vector<std::string>& antennaNames, const std::string& name);
 
 #endif

--- a/cli/limeConfig.cpp
+++ b/cli/limeConfig.cpp
@@ -43,22 +43,6 @@ static void LogCallback(LogLevel lvl, const std::string& msg)
     std::cout << msg << std::endl;
 }
 
-static int AntennaNameToIndex(const std::vector<std::string>& antennaNames, const std::string& name)
-{
-    if (name.empty())
-        return -1;
-
-    for (size_t j = 0; j < antennaNames.size(); ++j)
-    {
-        if (antennaNames[j] == name)
-            return j;
-    }
-    std::cerr << "Antenna ("sv << name << " not found. Available:"sv << std::endl;
-    for (const auto& iter : antennaNames)
-        std::cerr << "\t\""sv << iter << "\""sv << std::endl;
-    return -1;
-}
-
 int main(int argc, char** argv)
 {
     // clang-format off

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(basicRX PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${examplesOutp
 target_link_libraries(
     basicRX
     PUBLIC limesuiteng
-    PRIVATE kissfft taywee::args)
+    PRIVATE cli-shared kissfft taywee::args)
 
 add_executable(dualRXTX dualRXTX.cpp)
 set_target_properties(dualRXTX PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${examplesOutputDir})
@@ -29,7 +29,10 @@ target_link_libraries(dualRXTX PUBLIC limesuiteng)
 
 add_executable(basicTX basicTX.cpp)
 set_target_properties(basicTX PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${examplesOutputDir})
-target_link_libraries(basicTX PUBLIC limesuiteng)
+target_link_libraries(
+    basicTX
+    PUBLIC limesuiteng
+    PRIVATE cli-shared kissfft taywee::args)
 
 add_executable(legacyBasicRX legacy/basicRX.cpp)
 set_target_properties(legacyBasicRX PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${examplesOutputDir}/legacy RUNTIME_OUTPUT_NAME basicRX)


### PR DESCRIPTION
Added device (--device or -d) and local frequency (--rxlo) selection to the basicRX example.

Added device selection, local frequency (--rxlo) and antenna (--txpath) selection to the basicTX example.

Since the antenna name to index is used in multiple places now the utility function for it has been moved to the common command line utilities.