### PR TITLE
Update grc files to support lime XTRX

### DIFF
--- a/plugins/gr-limesdr/grc/limesdr_sink.block.yml
+++ b/plugins/gr-limesdr/grc/limesdr_sink.block.yml
@@ -275,7 +275,7 @@ asserts:
 - ${ 73 >= gain_dB_ch1 }
 
 - ${ samp_rate > 0 }
-- ${ 61.44e6 >= samp_rate }
+- ${ 120.0e6 >= samp_rate }
 
 inputs:
 - label: in
@@ -304,6 +304,7 @@ documentation: |-
   RF FREQUENCY
 
   Set RF center frequency for TX (both channels).
+  LimeSDR-XTRX supports   [30e6,3800e6] Hz.
   LimeSDR-USB supports	  [100e3,3800e6] Hz.
   LimeSDR-PCIe supports	  [100e3,3800e6] Hz.
   LimeSDR-Mini supports	  [10e6,3500e6] Hz.
@@ -313,6 +314,7 @@ documentation: |-
 
   Here you can enter sample rate for TX.
 
+  LimeSDR-XTRX sample rate must be no more than 120.0e6 S/s.
   LimeSDR-USB sample rate must be no more than 61.44e6 S/s.
   LimeSDR-PCIe sample rate must be no more than 61.44e6 S/s.
   LimeSDR-Mini sample rate must be no more than 30.72e6 S/s.

--- a/plugins/gr-limesdr/grc/limesdr_source.block.yml
+++ b/plugins/gr-limesdr/grc/limesdr_source.block.yml
@@ -271,7 +271,7 @@ asserts:
 - ${ 73 >= gain_dB_ch1 }
 
 - ${ samp_rate > 0 }
-- ${ 61.44e6 >= samp_rate }
+- ${ 120.0e6 >= samp_rate }
 
 outputs:
 - label: out
@@ -300,6 +300,7 @@ documentation: |-
   RF FREQUENCY
   
   Set RF center frequency for RX (both channels).
+  LimeSDR-XTRX supports   [30e6,3800e6]   Hz.
   LimeSDR-USB supports 	  [100e3,3800e6] 	Hz.
   LimeSDR-PCIe supports 	[100e3,3800e6] 	Hz.
   LimeSDR-Mini supports 	[10e6,3500e6] 	Hz.
@@ -309,6 +310,7 @@ documentation: |-
   
   Here you can enter sample rate for RX.
   
+  LimeSDR-XTRX sample rate must be no more than 120.0e6 S/s.
   LimeSDR-USB sample rate must be no more than 61.44e6 S/s.
   LimeSDR-PCIe sample rate must be no more than 61.44e6 S/s.
   LimeSDR-Mini sample rate must be no more than 30.72e6 S/s.


### PR DESCRIPTION
The frequency range allowed in the GRC files is much less than what the XTRX supports.  Update that value and a few comments.