### PR TITLE
Updating limeSPI cli flags in getting started documentation

### DIFF
--- a/docs/gettingStarted/common/cliTools.rst
+++ b/docs/gettingStarted/common/cliTools.rst
@@ -57,8 +57,8 @@ Utility for reading/writing device's SPI registers
 
 .. code-block:: bash
 
-	user@computer:~$ limeSPI --chip LMS7002M --write=0020fffd
-	user@computer:~$ limeSPI --chip LMS7002M --read=0020
+	user@computer:~$ limeSPI write --chip LMS7002M --stream=0020fffd
+	user@computer:~$ limeSPI read --chip LMS7002M --stream=0020
 	0020fffd
 
 limeFLASH


### PR DESCRIPTION
Noticed that the `--read` and `--write` flags had changed. 