### PR TITLE
fix typo in BUILD_PLUGINS_SOAPYSDR CMake option

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 find_package(SoapySDR CONFIG)
 cmake_dependent_option(BUILD_PLUGINS_SOAPYSDR "Build LimeSuiteNG SoapySDR bindings" ON "BUILD_CORE;SoapySDR_FOUND" OFF)
 add_feature_info("BUILD_PLUGINS_SOAPYSDR" BUILD_PLUGINS_SOAPYSDR "SoapySDR bindings for LimeSuiteNG")
-if(BUILD_PLUGIN_SOAPYSDR)
+if(BUILD_PLUGINS_SOAPYSDR)
     add_subdirectory(Soapy_limesuiteng)
 endif()
 


### PR DESCRIPTION
Fix typo in the `BUILD_PLUGINS_SOAPYSDR` CMake option.