### PR TITLE
Fix building of the limepcie kernel module with CMake v3.19 and older

### DIFF
--- a/drivers/linux/limepcie/cmake/add_kernel_module.cmake
+++ b/drivers/linux/limepcie/cmake/add_kernel_module.cmake
@@ -89,15 +89,13 @@ function(add_kernel_module)
     endif()
 
     # add external configured files to sources,so they get copied during install
-    foreach(SRC_FILENAME ${KMOD_CONFIGURED_FILES})
-        target_sources(${KMOD_NAME} PRIVATE ${SRC_FILENAME})
-    endforeach()
+    set_property(TARGET ${KMOD_NAME} APPEND PROPERTY SOURCES ${KMOD_CONFIGURED_FILES})
 
     # Copy all source files into build directory and compile there, as the Kbuild produces artifacts in tree
     foreach(SRC_FILENAME ${KMOD_SOURCES})
         configure_file(${SRC_FILENAME} ${KBUILD_FILE_DIR}/${SRC_FILENAME} COPYONLY)
     endforeach()
-    target_sources(${KMOD_NAME} PRIVATE ${KMOD_SOURCES})
+    set_property(TARGET ${KMOD_NAME} APPEND PROPERTY SOURCES ${KMOD_SOURCES})
 
     # Pick compilable source files
     string(REGEX MATCHALL "[^ ;]+[.]c" KERNEL_OBJECTS_RELATIVE_PATHS "${KMOD_SOURCES}")


### PR DESCRIPTION
CMake has different behavior of the `target_source` directive across versions. In particular, in older versions (v3.19 and older) the directive is supported only for targets previously declared via `add_executable` or `add_library`. But starting from v3.20 it also supports targets declared via `add_custom_target`.

See for reference:
    https://cmake.org/cmake/help/v3.20/command/target_sources.html

As a result, the module can be built on some hosts (Debian 11).

The patch has been successfully tested on the following hosts:
 - Debian 11;
 - Ubuntu 24.04.

See additional comments and testing details in the commit message.