### PR TITLE
LimeSDR: Add ADF4002 to limeGUI

### DIFF
--- a/src/boards/LimeSDR/CMakeLists.txt
+++ b/src/boards/LimeSDR/CMakeLists.txt
@@ -1,1 +1,1 @@
-target_sources(limesuiteng PRIVATE LimeSDR.cpp USB_CSR_Pipe_SDR.cpp)
+target_sources(limesuiteng PRIVATE LimeSDR.cpp USB_CSR_Pipe_SDR.cpp LMS64C_ADF_Over_USB.cpp)

--- a/src/boards/LimeSDR/LMS64C_ADF_Over_USB.cpp
+++ b/src/boards/LimeSDR/LMS64C_ADF_Over_USB.cpp
@@ -1,0 +1,20 @@
+#include "LMS64C_ADF_Over_USB.h"
+#include "protocols/LMS64CProtocol.h"
+
+using namespace lime;
+
+LMS64C_ADF_Over_USB::LMS64C_ADF_Over_USB(std::shared_ptr<ISerialPort> serialPort, uint32_t subdeviceIndex)
+    : mSerialPort(serialPort)
+    , mSubdeviceIndex(subdeviceIndex)
+{
+}
+
+OpStatus LMS64C_ADF_Over_USB::SPI(const uint32_t* MOSI, uint32_t* MISO, uint32_t count)
+{
+    return LMS64CProtocol::ADF4002_SPI(*(mSerialPort.get()), MOSI, count, mSubdeviceIndex);
+}
+
+OpStatus LMS64C_ADF_Over_USB::SPI(uint32_t spiBusAddress, const uint32_t* MOSI, uint32_t* MISO, uint32_t count)
+{
+    return LMS64CProtocol::ADF4002_SPI(*(mSerialPort.get()), MOSI, count, mSubdeviceIndex);
+}

--- a/src/boards/LimeSDR/LMS64C_ADF_Over_USB.h
+++ b/src/boards/LimeSDR/LMS64C_ADF_Over_USB.h
@@ -1,0 +1,33 @@
+#ifndef LIME_LMS64C_ADF_OVER_USB_LIMESDR_H
+#define LIME_LMS64C_ADF_OVER_USB_LIMESDR_H
+
+#include "comms/IComms.h"
+#include "comms/ISerialPort.h"
+
+#include <cstdint>
+#include <memory>
+
+namespace lime {
+
+/** @brief A class for communicating with LimeSDR's subdevice's ADF4002 chips. */
+class LMS64C_ADF_Over_USB : public ISPI
+{
+  public:
+    /**
+      @brief Constructs a new LMS64C_ADF_Over_USB object
+      @param serialPort The serial port the ADF4002 is connected to
+      @param subdeviceIndex The subdevice index of the ADF4002 on serialPort
+     */
+    LMS64C_ADF_Over_USB(std::shared_ptr<ISerialPort> serialPort, uint32_t subdeviceIndex);
+
+    OpStatus SPI(const uint32_t* MOSI, uint32_t* MISO, uint32_t count) override;
+    OpStatus SPI(uint32_t spiBusAddress, const uint32_t* MOSI, uint32_t* MISO, uint32_t count) override;
+
+  private:
+    std::shared_ptr<ISerialPort> mSerialPort;
+    uint32_t mSubdeviceIndex;
+};
+
+} // namespace lime
+
+#endif // LIME_LMS64C_ADF_OVER_USB_LIMESDR_H

--- a/src/boards/LimeSDR/LimeSDR.h
+++ b/src/boards/LimeSDR/LimeSDR.h
@@ -3,6 +3,7 @@
 
 #include "boards/LMS7002M_SDRDevice.h"
 #include "protocols/LMS64CProtocol.h"
+#include "chips/ADF4002/ADF4002.h"
 
 #include <vector>
 #include <memory>
@@ -70,6 +71,7 @@ class LimeSDR : public LMS7002M_SDRDevice
     std::shared_ptr<ISerialPort> mSerialPort;
     std::shared_ptr<IComms> mlms7002mPort;
     std::shared_ptr<IComms> mfpgaPort;
+    std::unique_ptr<ADF4002> mADF;
     bool mConfigInProgress;
 };
 


### PR DESCRIPTION
Add the ADF4002 to the LimeSDR's socTree such that it will show up in limeGUI.

This was tested on a LimeSDR board and using the GUI interface was confirmed to properly affect the chip. Muxout was changed to both DVdd and DGND and confirmed at R160 with a multi-meter.