### PR TITLE
Fix GUI compilation error on macOS with system GLEW

### DIFF
--- a/GUI/oglGraph/CMakeLists.txt
+++ b/GUI/oglGraph/CMakeLists.txt
@@ -26,9 +26,7 @@ if(TARGET OpenGL::GL) # GLEW header needs GL/gl.h
 
         if(NOT TARGET GLEW::GLEW)
             add_library(GLEW::GLEW INTERFACE IMPORTED)
-            set_target_properties(GLEW::GLEW PROPERTIES
-                INTERFACE_LINK_LIBRARIES GLEW
-            )
+            set_target_properties(GLEW::GLEW PROPERTIES INTERFACE_LINK_LIBRARIES GLEW)
         endif()
     endif()
 else()

--- a/GUI/oglGraph/CMakeLists.txt
+++ b/GUI/oglGraph/CMakeLists.txt
@@ -4,7 +4,6 @@
 set(OpenGL_GL_PREFERENCE GLVND)
 find_package(OpenGL REQUIRED)
 if(TARGET OpenGL::GL) # GLEW header needs GL/gl.h
-    # OSX has can have glew package, but it's includes fail.
     find_package(GLEW) # use system libs
     if(NOT GLEW_FOUND)
         fetchcontent_declare(
@@ -24,6 +23,13 @@ if(TARGET OpenGL::GL) # GLEW header needs GL/gl.h
 
         # compile only when other targets link to it
         set_target_properties(GLEW PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
+
+        if(NOT TARGET GLEW::GLEW)
+            add_library(GLEW::GLEW INTERFACE IMPORTED)
+            set_target_properties(GLEW::GLEW PROPERTIES
+                INTERFACE_LINK_LIBRARIES GLEW
+            )
+        endif()
     endif()
 else()
     message(FATAL_ERROR "OpenGL/GL not found!")
@@ -41,4 +47,4 @@ elseif(UNIX)
     set(GL_LIBS ${OPENGL_LIBRARIES})
 endif()
 
-target_link_libraries(limeGUI PRIVATE GLEW ${GL_LIBS})
+target_link_libraries(limeGUI PRIVATE GLEW::GLEW ${GL_LIBS})


### PR DESCRIPTION
The reason why includes are failing is because the GLEW include directories might not be in the system ones (as it is typically installed via Homebrew).

The way CMake code was structures it was linking directly to the GLEW library (instead of using imported target or using the GLEW_LIBRARIES), and it was not using GLEW_INCLUDE_DIRS.

This change makes it so limeGUI is linked against GLEW::GLEW imported target which makes it so the GLEW include directories are configured for the limeGUI. For the case when system-wide GLEW is not installed an imported target is created from the compiled GLEW library.

Tested both scenarios (GLEW available and is not available) by commenting out find_package(GLEW) and doing a full clean build.