### PR TITLE
Fixes for the macOS retina display and dark theme

### DIFF
--- a/GUI/oglGraph/OpenGLGraph.cpp
+++ b/GUI/oglGraph/OpenGLGraph.cpp
@@ -917,6 +917,10 @@ void OpenGLGraph::Fit()
 */
 void OpenGLGraph::OnMouseDown(int mouseButton, int X, int Y)
 {
+    const float scale = GetContentScaleFactor();
+    X *= scale;
+    Y *= scale;
+
     if constexpr (OGL_INVERT_MOUSE_Y)
     {
         Y = settings.windowHeight - Y;
@@ -967,6 +971,15 @@ void OpenGLGraph::OnMouseDown(int mouseButton, int X, int Y)
 */
 void OpenGLGraph::OnMouseUp(int mouseButton, int X, int Y)
 {
+    /* Coordinate within the graph window measured in the window (logical)
+     * coordinate system (without device scaling applied). */
+    const int X_window = X;
+    const int Y_window = Y;
+
+    const float scale = GetContentScaleFactor();
+    X *= scale;
+    Y *= scale;
+
     switch (mouseButton)
     {
     case OGLG_LEFT:
@@ -997,7 +1010,7 @@ void OpenGLGraph::OnMouseUp(int mouseButton, int X, int Y)
 
     case OGLG_RIGHT:
         if ((m_MouseCoord.x2 == m_MouseCoord.x1) && (m_MouseCoord.y2 == m_MouseCoord.y1))
-            ShowMenu(X, Y);
+            ShowMenu(X_window, Y_window);
         break;
     }
     m_actionState = OGLG_IDLE;
@@ -1012,6 +1025,10 @@ void OpenGLGraph::OnMouseUp(int mouseButton, int X, int Y)
 */
 void OpenGLGraph::OnMouseMove(int X, int Y)
 {
+    const float scale = GetContentScaleFactor();
+    X *= scale;
+    Y *= scale;
+
     float spanx, spany, sx, sy;
     if constexpr (OGL_INVERT_MOUSE_Y)
     {

--- a/GUI/utility/pnlMiniLog.cpp
+++ b/GUI/utility/pnlMiniLog.cpp
@@ -60,6 +60,19 @@ pnlMiniLog::pnlMiniLog(wxWindow* parent, wxWindowID id, const wxPoint& pos, cons
 
     mDefaultStyle = txtMessageField->GetDefaultStyle();
     wxUpdateUIEvent::SetUpdateInterval(100);
+
+    // Explicitly set the text color. Without this setting the style back to the
+    // default will always use the black color. Explicitly setting the color to
+    // the color provided via the default attribute makes the text colored
+    // correctly on both dark and light modes.
+    //
+    // Do it for both foreground and background, so that the style can be fully
+    // restored after it has been altered for the error or warning.
+    const wxVisualAttributes attr = txtMessageField->GetDefaultAttributes();
+    if (!mDefaultStyle.HasTextColour())
+        mDefaultStyle.SetTextColour(attr.colFg);
+    if (!mDefaultStyle.HasBackgroundColour())
+        mDefaultStyle.SetBackgroundColour(attr.colBg);
 }
 
 static const char* logLevelToName(const LogLevel level)


### PR DESCRIPTION
This PR consists of the fixes previously made to the LimeSuite repository:
- myriadrf/LimeSuite@49880e7f865
- myriadrf/LimeSuite@884070e490a
- myriadrf/LimeSuite@cc09db1f9b0
The latter two are squished together since they are actually related to each other.

This fixes mouse behavior in the OpenGL graph on Retina displays which has a difference between logical and physical pixels. It also fixes text in the mini log always being black which is hard to read when using dark macOS theme.

The  PR consists of two consecutive commits to make it easier to track, if needed.