### PR TITLE
Use CalibrationFlag enum for channel configuration

### DIFF
--- a/plugins/HDSDR/src/ExtIO_LimeSDR.cpp
+++ b/plugins/HDSDR/src/ExtIO_LimeSDR.cpp
@@ -291,7 +291,7 @@ static bool InitializeLMS()
     channelConfiguration.oversample = oversample;
     channelConfiguration.centerFrequency = currentLOFreq;
     channelConfiguration.path = antennaSelect;
-    channelConfiguration.calibrate = CalibrationFlag::DCIQ;
+    channelConfiguration.calibrate = lime::CalibrationFlag::DCIQ;
     channelConfiguration.gain[lime::eGainTypes::LNA] = LNA;
     channelConfiguration.gain[lime::eGainTypes::PGA] = PGA;
     channelConfiguration.gain[lime::eGainTypes::TIA] = TIA;

--- a/plugins/HDSDR/src/ExtIO_LimeSDR.cpp
+++ b/plugins/HDSDR/src/ExtIO_LimeSDR.cpp
@@ -291,7 +291,7 @@ static bool InitializeLMS()
     channelConfiguration.oversample = oversample;
     channelConfiguration.centerFrequency = currentLOFreq;
     channelConfiguration.path = antennaSelect;
-    channelConfiguration.calibrate = true;
+    channelConfiguration.calibrate = CalibrationFlag::DCIQ;
     channelConfiguration.gain[lime::eGainTypes::LNA] = LNA;
     channelConfiguration.gain[lime::eGainTypes::PGA] = PGA;
     channelConfiguration.gain[lime::eGainTypes::TIA] = TIA;

--- a/src/examples/basicRX.cpp
+++ b/src/examples/basicRX.cpp
@@ -114,7 +114,7 @@ int main(int argc, char** argv)
     config.channel[0].rx.oversample = 2;
     config.channel[0].rx.lpf = 0;
     config.channel[0].rx.path = rxPath;
-    config.channel[0].rx.calibrate = false;
+    config.channel[0].rx.calibrate = CalibrationFlag::NONE;
     config.channel[0].rx.testSignal.enabled = false;
 
     config.channel[0].tx.enabled = false;

--- a/src/examples/basicTX.cpp
+++ b/src/examples/basicTX.cpp
@@ -109,7 +109,7 @@ int main(int argc, char** argv)
     config.channel[0].tx.oversample = 2;
     config.channel[0].tx.lpf = 0;
     config.channel[0].tx.path = txPath;
-    config.channel[0].tx.calibrate = true;
+    config.channel[0].tx.calibrate = CalibrationFlag::DCIQ;
     config.channel[0].tx.testSignal.enabled = false;
 
     std::cout << "Configuring device ...\n"sv;

--- a/src/examples/dualRXTX.cpp
+++ b/src/examples/dualRXTX.cpp
@@ -69,14 +69,14 @@ int main(int argc, char** argv)
         config.channel[c].rx.oversample = 2;
         config.channel[c].rx.lpf = 0;
         config.channel[c].rx.path = 2; // TODO: replace with string names
-        config.channel[c].rx.calibrate = false;
+        config.channel[c].rx.calibrate = CalibrationFlag::NONE;
 
         config.channel[c].tx.enabled = true;
         config.channel[c].tx.sampleRate = sampleRate;
         config.channel[c].tx.oversample = 2;
         config.channel[c].tx.path = 2; // TODO: replace with string names
         config.channel[c].tx.centerFrequency = frequencyLO;
-        config.channel[c].tx.calibrate = false;
+        config.channel[c].tx.calibrate = CalibrationFlag::NONE;
     }
 
     // Samples data streaming configuration

--- a/src/include/limesuiteng/SDRConfig.h
+++ b/src/include/limesuiteng/SDRConfig.h
@@ -82,7 +82,7 @@ struct ChannelConfig {
         uint8_t oversample; ///< The oversample ratio of this direction.
         GFIRFilter gfir; ///< The general finite impulse response (FIR) filter settings of this direction.
         bool enabled; ///< Denotes whether this direction of a channel is enabled or not.
-        uint32_t calibrate; ///< Which calibration to perform.
+        uint32_t calibrate; ///< Which calibration to perform (a bitmask of CalibrationFlag).
         TestSignal testSignal; ///< Denotes whether the signal being sent is a test signal or not.
     };
 
@@ -123,7 +123,7 @@ struct SDRConfig {
     static constexpr uint8_t MAX_CHANNEL_COUNT = 16; ///< Maximum amount of channels an SDR Device can hold
     SDRConfig()
         : referenceClockFreq(0)
-        , skipDefaults(false){};
+        , skipDefaults(false) {};
     double referenceClockFreq; ///< The reference clock frequency of the device.
     ChannelConfig channel[MAX_CHANNEL_COUNT]; ///< The configuration settings for each of the channels.
     // Loopback setup?

--- a/src/include/limesuiteng/SDRConfig.h
+++ b/src/include/limesuiteng/SDRConfig.h
@@ -123,7 +123,7 @@ struct SDRConfig {
     static constexpr uint8_t MAX_CHANNEL_COUNT = 16; ///< Maximum amount of channels an SDR Device can hold
     SDRConfig()
         : referenceClockFreq(0)
-        , skipDefaults(false) {};
+        , skipDefaults(false){};
     double referenceClockFreq; ///< The reference clock frequency of the device.
     ChannelConfig channel[MAX_CHANNEL_COUNT]; ///< The configuration settings for each of the channels.
     // Loopback setup?

--- a/src/utilities/rfTest.cpp
+++ b/src/utilities/rfTest.cpp
@@ -66,8 +66,8 @@ TestConfigType generateTestConfig(bool mimo, float sampleRate)
         config.channel[i].rx.gfir.bandwidth = config.channel[i].rx.lpf;
         config.channel[i].rx.path = 2; // Loopback_1 // TODO: replace with string names
         config.channel[i].tx.path = 2; // band1 // TODO: replace with string names
-        config.channel[i].rx.calibrate = false;
-        config.channel[i].tx.calibrate = false;
+        config.channel[i].rx.calibrate = CalibrationFlag::NONE;
+        config.channel[i].tx.calibrate = CalibrationFlag::NONE;
         config.channel[i].rx.testSignal.enabled = false;
         config.channel[i].tx.testSignal.enabled = false;
     }

--- a/tests/streaming/RFStream_tests.cpp
+++ b/tests/streaming/RFStream_tests.cpp
@@ -41,7 +41,7 @@ void RFStream_tests::SetUp()
     config.channel[0].rx.oversample = 2;
     config.channel[0].rx.lpf = 0;
     config.channel[0].rx.path = 2; // TODO: replace with string names
-    config.channel[0].rx.calibrate = false;
+    config.channel[0].rx.calibrate = CalibrationFlag::NONE;
     config.channel[0].rx.testSignal.enabled = false;
 
     config.channel[0].tx.enabled = false;

--- a/tests/streaming/streaming.cpp
+++ b/tests/streaming/streaming.cpp
@@ -40,7 +40,7 @@ void SDRDevice_streaming::SetUp()
     config.channel[0].rx.oversample = 2;
     config.channel[0].rx.lpf = 0;
     config.channel[0].rx.path = 2; // TODO: replace with string names
-    config.channel[0].rx.calibrate = false;
+    config.channel[0].rx.calibrate = CalibrationFlag::NONE;
     config.channel[0].rx.testSignal.enabled = false;
 
     config.channel[0].tx.enabled = false;


### PR DESCRIPTION
The configuration field for calibration has changed from bool to CalibrationFlag in some previous commit, but some code was still assigning it as if it is boolean.

In places where calibration was not needed it is a simple change to CalibrationFlag::NONE. In other cases use DCIQ calibration as it seems to be the one which was actually performed in those cases prior to the change of the configuration.