### PR TITLE
do not expose lms_gfir objects to users of lib

### DIFF
--- a/src/chips/LMS7002M/CMakeLists.txt
+++ b/src/chips/LMS7002M/CMakeLists.txt
@@ -12,6 +12,6 @@ set(LMS7002M_SOURCES
 
 target_sources(limesuiteng PRIVATE ${LMS7002M_SOURCES})
 target_link_libraries(limesuiteng PRIVATE $<BUILD_INTERFACE:lms7002m>)
-target_link_libraries(limesuiteng PRIVATE $<TARGET_OBJECTS:lms_gfir>)
+target_link_libraries(limesuiteng PRIVATE $<BUILD_INTERFACE:$<TARGET_OBJECTS:lms_gfir>>)
 
 target_include_directories(limesuiteng PRIVATE ${PROJECT_SOURCE_DIR}/embedded/include)


### PR DESCRIPTION
lms_gfir is an object library and is added to the user of limesuiteng, by virtue of the install(EXPORT generated script. This is comewhat surprising since the library is linked with PRIVATE scope.

The following in src/chips/LMS7002/CMakeLists.txt removes the error, however:

```
target_link_libraries(limesuiteng PRIVATE $<BUILD_INTERFACE:$<TARGET_OBJECTS:lms_gfir>>)
```
A merge would close issue #135 .