### PR TITLE
for static build export kissfft as a private lib

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,19 @@ install(
     RUNTIME DESTINATION bin # .dll file
 )
 
+if(NOT BUILD_SHARED_LIBS)
+    # install with a prefix, so will not interfere with kissfft lib
+    set_target_properties(kissfft PROPERTIES PREFIX "liblimesuiteng-")
+    install(
+        TARGETS kissfft
+        EXPORT limesuitengTarget
+        COMPONENT RUNTIME
+        DESTINATION lib${LIB_SUFFIX} # .so file
+        ARCHIVE DESTINATION lib${LIB_SUFFIX} # .lib file
+        RUNTIME DESTINATION bin # .dll file
+    )
+endif()
+
 ########################################################################
 ## lime suite library
 ########################################################################


### PR DESCRIPTION
When statically linking to liblimesuiteng one
also needs to link against the kissft lib.
Since the user may or may not have installed
kissfft as a static lib, we provide a private
version which is linked as liblimesuiteng-kissfft-float.a when linking against liblimesuiteng.
When the user also has installed the upstream
kissfft she may link against this version, but
then the results become dependent on where the
both libraries appear on the linker line.
Usually the first wins. So take care!

This pull request will resolve issue #131 