### PR TITLE
Fix wrong arg order in debug log message

### DIFF
--- a/GUI/boards/CMakeLists.txt
+++ b/GUI/boards/CMakeLists.txt
@@ -1,1 +1,3 @@
-target_sources(limeGUI PRIVATE pnlBoardControls.cpp pnlGPIO.cpp pnlX3.cpp pnlX8.cpp pnlXTRX.cpp pnluLimeSDR.cpp pnlLimeSDR.cpp pnlGPIO_Interface.cpp)
+target_sources(
+    limeGUI
+    PRIVATE pnlBoardControls.cpp pnlGPIO.cpp pnlX3.cpp pnlX8.cpp pnlXTRX.cpp pnluLimeSDR.cpp pnlLimeSDR.cpp pnlGPIO_Interface.cpp)

--- a/src/threadHelper/threadHelper.cpp
+++ b/src/threadHelper/threadHelper.cpp
@@ -55,9 +55,9 @@ int lime::SetOSThreadPriority(ThreadPriority priority, ThreadPolicy policy, std:
     {
         lime::debug("SetOSThreadPriority: Failed to set priority(%d), sched_prio(%d), policy(%d), ret(%d)",
             static_cast<int>(priority),
+            sch.sched_priority,
             sched_policy,
-            ret,
-            sch.sched_priority);
+            ret);
         return -1;
     }
 


### PR DESCRIPTION
In function lime::SetOSThreadPriority of file threadHelper.cpp the arguments to the debug log are in the wrong order.