### PR TITLE
Fix another bogus arg order for log message

### DIFF
--- a/src/threadHelper/threadHelper.cpp
+++ b/src/threadHelper/threadHelper.cpp
@@ -100,9 +100,9 @@ int lime::SetOSCurrentThreadPriority(ThreadPriority priority, ThreadPolicy polic
     {
         lime::debug("SetOSCurrentThreadPriority: Failed to set priority(%d), sched_prio(%d), policy(%d), ret(%d)",
             static_cast<int>(priority),
+            sch.sched_priority,
             sched_policy,
-            ret,
-            sch.sched_priority);
+            ret);
         return -1;
     }
 


### PR DESCRIPTION
Another small issue, likely a copy and paste error of the previous reported issue.