### PR TITLE
Avoid off by one error, rounding GetTicks calc

### DIFF
--- a/src/streaming/Timespec.cpp
+++ b/src/streaming/Timespec.cpp
@@ -86,7 +86,7 @@ uint64_t Timespec::GetTicks() const
 {
     if (seconds < 0)
         return 0;
-    return seconds * ticksPerSecond + fracSeconds * ticksPerSecond;
+    return round(seconds * ticksPerSecond + fracSeconds * ticksPerSecond);
 }
 
 double Timespec::GetRealSeconds() const


### PR DESCRIPTION
GetTicks cast the result from double to uint64_t, occasionally causing errors of one tick. E.g. 6143.999999904 will be returned as 6143 while the correct value is 6144. Proper rounding fixes the problem.