### PR TITLE
debian: remove obsolete limepcie-dkms.dkms

### DIFF
--- a/debian/limepcie-dkms.dkms
+++ b/debian/limepcie-dkms.dkms
@@ -1,7 +1,0 @@
-PACKAGE_NAME="limepcie"
-PACKAGE_VERSION="0.1.9"
-MAKE[0]="make"
-CLEAN="make clean"
-BUILT_MODULE_NAME[0]="limepcie"
-DEST_MODULE_LOCATION[0]="/updates"
-AUTOINSTALL="yes"


### PR DESCRIPTION
There is an actual dkms config file template
(drivers/linux/limepcie/dkms.conf.in).
Remove obsolete static dkms config file (debian/limepcie-dkms.dkms) to fix
limepcie-dkms package install issue [1].

[1]
Setting up limepcie-dkms:amd64 (0.1.10) ...
Loading new limepcie/0.1.9 DKMS files...
...
Building for 6.14.0-35-generic and 6.14.0-36-generic
...
Error! The directory /var/lib/dkms/limepcie/0.1.9/source does not appear to have module source located within it.
Build halted.
...