### PR TITLE
Added functions for streaming dma mappings and for Cache syncronication

### DIFF
--- a/drivers/linux/la9310_limesdr/la9310_base.c
+++ b/drivers/linux/la9310_limesdr/la9310_base.c
@@ -424,6 +424,45 @@ la9310_init_subdrv_dma_buf(struct la9310_dev *la9310_dev)
 }
 
 static int
+la9310_alloc_dma_buf(struct device *dev, const char *buf_name, struct la9310_mem_region_info *buf_info, int buf_size, enum dma_data_direction dma_dir)
+{
+	int status;
+
+	buf_info->vaddr = kmalloc(buf_size, GFP_KERNEL);
+	if (!buf_info->vaddr) {
+		dev_err(dev, "Failed to allocate %s\n", buf_name);
+		return -ENOMEM;
+	}
+
+	buf_info->size = buf_size;
+	
+	buf_info->phys_addr = dma_map_single(dev, buf_info->vaddr, buf_size, dma_dir);
+	status = dma_mapping_error(dev, buf_info->phys_addr);
+	if (status) {
+		dev_err(dev, "dma_map_single error @ va:%p pa:%llX for %s\n", buf_info->vaddr, virt_to_phys(buf_info->vaddr), buf_name);
+		kfree(buf_info->vaddr);	       
+		return status;
+	}
+
+	dev_info(dev, "%s size: %i, va:0x%px pa:0x%llx bus:0x%llx\n", buf_name, buf_size, buf_info->vaddr, virt_to_phys(buf_info->vaddr), buf_info->phys_addr);
+	return 0;
+}
+
+static int
+la9310_free_dma_buf(struct device *dev, const char *buf_name, struct la9310_mem_region_info *buf_info, enum dma_data_direction dma_dir)
+{
+	dev_info(dev, "Unmap and free %s size: %ll, va:0x%px pa:0x%llx bus:0x%llx\n", buf_name, buf_info->size, buf_info->vaddr, virt_to_phys(buf_info->vaddr), buf_info->phys_addr);
+	if (buf_info->phys_addr)
+		dma_unmap_single(dev, buf_info->phys_addr, buf_info->size, dma_dir);
+	if (buf_info->vaddr)
+		kfree(buf_info->vaddr);
+
+	dev_info(dev, "Unmapped and freed %s\n", buf_name);
+
+	return 0;
+}
+
+static int
 la9310_scratch_dma_buf(struct la9310_dev *la9310_dev)
 {
 	struct la9310_dma_info *dma_info = &la9310_dev->dma_info;
@@ -432,20 +471,12 @@ la9310_scratch_dma_buf(struct la9310_dev *la9310_dev)
 
 	la9310_dev->scratch_buf_size = 4 * (1024 * 1024);
 
-	dma_addr_t scratch_buffer_bus;
-    void *scratch_buffer_va = dma_alloc_coherent(la9310_dev->dev, la9310_dev->scratch_buf_size, &scratch_buffer_bus, GFP_KERNEL);
-    if (!scratch_buffer_va)
-    {
-        dev_err(la9310_dev->dev, "Failed to allocate scratch buffer\n");
-        return -ENOMEM;
-    }
-    dev_info(la9310_dev->dev, "Scratch buf size: %i, va:0x%px pa:0x%llx bus:0x%llx\n", la9310_dev->scratch_buf_size, scratch_buffer_va, virt_to_phys(scratch_buffer_va), scratch_buffer_bus);
+	rc = la9310_alloc_dma_buf(la9310_dev->dev, "Scratch buffer", host_region, la9310_dev->scratch_buf_size, DMA_BIDIRECTIONAL);
 
-    host_region->vaddr = scratch_buffer_va;
-    host_region->phys_addr = scratch_buffer_bus;
-	host_region->size = la9310_dev->scratch_buf_size;
+	if (rc)
+		return rc;
 
-    la9310_dev->scratch_buf_phys_addr = scratch_buffer_bus;
+	la9310_dev->scratch_buf_phys_addr = host_region->phys_addr;
 
 	if ((!host_region->vaddr) || (la9310_dev->scratch_buf_size < LA9310_DMA_BUF_SIZE)) {
 		dev_err(la9310_dev->dev, "ERR: ioremap DDR Address Failed\n");
@@ -459,7 +490,7 @@ la9310_scratch_dma_buf(struct la9310_dev *la9310_dev)
 	rc = la9310_scratch_outbound_create(la9310_dev);
 	if (rc) {
 		dev_err(la9310_dev->dev,
-			"scratch buf outbound window creation failed\n");
+				"scratch buf outbound window creation failed\n");
 		goto out;
 	}
 
@@ -748,57 +779,21 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 		goto out;
 	}
 
-    la9310_dev->iq_mem_size = 4 * 1024 * 1024;
+	la9310_dev->iq_mem_size = 4 * 1024 * 1024;
 
-    dma_addr_t iq_mem_Handle;
-    void *iq_mem_data = dma_alloc_coherent(la9310_dev->dev, la9310_dev->iq_mem_size, &iq_mem_Handle, GFP_KERNEL);
-    if (!iq_mem_data)
-    {
-        dev_err(la9310_dev->dev, "Failed to allocate iq_mem_data buffer\n");
-        return -ENOMEM;
-    }
-    dev_info(la9310_dev->dev, "iq_mem_data buf size: %i, va:%px bus:%llx\n", la9310_dev->iq_mem_size, iq_mem_data, iq_mem_Handle);
-    la9310_dev->iq_mem_addr = iq_mem_Handle;
-
-    la9310_dev->iqflood_region.vaddr = iq_mem_data;
-    la9310_dev->iqflood_region.phys_addr = iq_mem_Handle;
-    la9310_dev->iqflood_region.size = la9310_dev->iq_mem_size;
-
-	// if (la9310_dev->iq_mem_addr ==0) {
-	// 	np = of_find_node_by_name(NULL, "iqflood");
-	// 	if (!np)
-	// 		np = of_find_node_by_name(NULL, "iq");
-
-	// 	if (np) {
-	// 		rc = of_address_to_resource(np, 0, &mem_addr);
-	// 		if (!rc) {
-	// 			la9310_dev->iq_mem_addr = mem_addr.start;
-	// 			la9310_dev->iq_mem_size = resource_size(&mem_addr);
-	// 		}
-	// 		of_node_put(np);
-	// 	}
-	// }
+	rc = la9310_alloc_dma_buf(la9310_dev->dev, "IQ Flood Buffer", &la9310_dev->iqflood_region, la9310_dev->iq_mem_size, DMA_BIDIRECTIONAL);
+	if (rc)
+		goto out;
+	la9310_dev->iq_mem_addr = la9310_dev->iqflood_region.phys_addr;
 
 	la9310_create_rfnm_iqflood_outbound(la9310_dev);
+	rc = la9310_alloc_dma_buf(la9310_dev->dev, "VSPA DMEM Proxy Buffer", &la9310_dev->dmem_proxy, VSPA_DMEM_PROXY_SIZE, DMA_BIDIRECTIONAL);
+	if (rc)
+		goto free_iqflood;
 
-	dma_addr_t dmem_proxy_Handle;
-    la9310_dev->dmem_proxy.size = VSPA_DMEM_PROXY_SIZE;
-    la9310_dev->dmem_proxy.vaddr = dma_alloc_coherent(la9310_dev->dev, la9310_dev->dmem_proxy.size, &dmem_proxy_Handle, GFP_KERNEL);
-    la9310_dev->dmem_proxy.phys_addr = dmem_proxy_Handle;
-    if (!la9310_dev->dmem_proxy.vaddr)
-    {
-        dev_err(la9310_dev->dev, "Failed to allocate dmem proxy buffer\n");
-        return -ENOMEM;
-    }
-    dev_info(la9310_dev->dev,
-        "vspa dmem proxy buf size: %li, va:%px pa:%llx bus:%llx\n",
-        la9310_dev->dmem_proxy.size,
-        la9310_dev->dmem_proxy.vaddr,
-        virt_to_phys(la9310_dev->dmem_proxy.vaddr),
-        la9310_dev->dmem_proxy.phys_addr);
-    la9310_create_ipc_outbound(la9310_dev);
+	la9310_create_ipc_outbound(la9310_dev);
 
-    rc = la9310_init_hif(la9310_dev);
+	rc = la9310_init_hif(la9310_dev);
 	if (rc)
 		goto out;
 	la9310_init_msg_unit_ptrs(la9310_dev);
@@ -912,32 +907,33 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 	// rc = la9310_modinfo_init(la9310_dev);
 
 	struct resource *tty_res = NULL;
-    tty_res = devm_kzalloc(la9310_dev->dev, sizeof(struct resource), GFP_KERNEL);
-    if (!tty_res)
-    {
-        dev_err(la9310_dev->dev, "Failed to allocate memory for UART\n");
-        return -1;
-    }
-    {
-        tty_res->start = (resource_size_t)la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR].vaddr + 0x21c0000;
-    }
-    tty_res->flags = IORESOURCE_REG;
-    char *devSymlink = devm_kzalloc(la9310_dev->dev, 64, GFP_KERNEL);
-    snprintf(devSymlink, 64, "limesdr_micro_uart");
-    tty_res->name = devSymlink;
-    la9310_dev->uart = platform_device_register_simple("la9310uart", 1, tty_res, 1);
-    if (IS_ERR(la9310_dev->uart))
-    {
-        dev_err(la9310_dev->dev, "Failed to register UART\n");
-        return -1;
-    }
+	tty_res = devm_kzalloc(la9310_dev->dev, sizeof(struct resource), GFP_KERNEL);
+	if (!tty_res)
+	{
+		dev_err(la9310_dev->dev, "Failed to allocate memory for UART\n");
+		return -1;
+	}
+	{
+		tty_res->start = (resource_size_t)la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR].vaddr + 0x21c0000;
+	}
+	tty_res->flags = IORESOURCE_REG;
+	char *devSymlink = devm_kzalloc(la9310_dev->dev, 64, GFP_KERNEL);
+	snprintf(devSymlink, 64, "limesdr_micro_uart");
+	tty_res->name = devSymlink;
+	la9310_dev->uart = platform_device_register_simple("la9310uart", 1, tty_res, 1);
+	if (IS_ERR(la9310_dev->uart))
+	{
+		dev_err(la9310_dev->dev, "Failed to register UART\n");
+		return -1;
+	}
 
+	return 0;
+free_iqflood:
+	la9310_free_dma_buf(la9310_dev->dev, "IQ FLood Buffer", &la9310_dev->iqflood_region, DMA_BIDIRECTIONAL);
 out:
 	if (rc)
 		la9310_base_deinit(la9310_dev, init_stage, i);
-
 	return rc;
-
 }
 
 static int
@@ -1035,11 +1031,12 @@ la9310_base_remove(struct la9310_dev *la9310_dev)
 
 	pci_disable_msi(la9310_dev->pdev);
 
+#if 0
     dma_free_coherent(la9310_dev->dev,
         la9310_dev->scratch_buf_size,
         la9310_dev->dma_info.host_buf.vaddr,
         la9310_dev->dma_info.host_buf.phys_addr);
-
+#endif
     la9310_unmap_mem_regions(la9310_dev);
 
 	// la9310_remove_sysfs(la9310_dev);

--- a/drivers/linux/la9310_limesdr/la9310_base.c
+++ b/drivers/linux/la9310_limesdr/la9310_base.c
@@ -795,18 +795,18 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 
 	rc = la9310_init_hif(la9310_dev);
 	if (rc)
-		goto out;
+		goto free_ipc;
 	la9310_init_msg_unit_ptrs(la9310_dev);
 	la9310_init_ep_logger(la9310_dev);
 
 	// rc = la9310_init_sysfs(la9310_dev);
 	// if (rc)
-	// 	goto out;
+	// 	goto free_ipc;
 	init_stage = LA9310_SYSFS_INIT_STAGE;
 
 	// rc = la9310_register_ep_stats_ops(la9310_dev);
 	// if (rc)
-	// 	goto out;
+	// 	goto free_ipc;
 
 	dev_info(la9310_dev->dev, "%s: Loading RTOS image\n",
 			la9310_dev->name);
@@ -814,14 +814,14 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 	if (rc) {
 		dev_err(la9310_dev->dev, "Failed to add RTOS image, err %d",
 				rc);
-		goto out;
+		goto free_ipc;
 	}
 
 #ifndef	LA9310_RESET_HANDSHAKE_POLLING_ENABLE
 	rc = la9310_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
 	if (rc) {
 		pr_err("%s: probe irq req failed, err %d\n", __func__, rc);
-		goto out;
+		goto free_ipc;
 	}
 
 	/*scrach register handshake request irq */
@@ -839,20 +839,20 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 	if (rc) {
 		dev_err(la9310_dev->dev, "Reset handshake failed, err %d",
 				rc);
-		goto out;
+		goto free_ipc;
 	}
 
 	/* Verify that Host and target are using same version of HIF */
 	rc = la9310_verify_hif_compatibility(la9310_dev);
 	if (rc)
-		goto out;
+		goto free_ipc;
 
 	init_stage = LA9310_IRQ_INIT_STAGE;
 #ifdef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
 	rc = la9310_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
 	if (rc) {
 		pr_err("%s: probe irq req failed, err %d\n", __func__, rc);
-		goto out;
+		goto free_ipc;
 	}
 #endif
 	/* WDOG request_irq */
@@ -899,7 +899,7 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 			if (rc) {
 				pr_err("%s: %s: probe failed, err %d\n",
 						__func__, &subdrv->name[0], rc);
-				goto out;
+				goto free_ipc;
 			}
 		}
 	}
@@ -911,7 +911,8 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 	if (!tty_res)
 	{
 		dev_err(la9310_dev->dev, "Failed to allocate memory for UART\n");
-		return -1;
+		rc = -1;
+		goto free_ipc;
 	}
 	{
 		tty_res->start = (resource_size_t)la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR].vaddr + 0x21c0000;
@@ -924,10 +925,13 @@ la9310_base_probe(struct la9310_dev *la9310_dev)
 	if (IS_ERR(la9310_dev->uart))
 	{
 		dev_err(la9310_dev->dev, "Failed to register UART\n");
-		return -1;
+		rc = -1;
+		goto free_ipc;
 	}
 
 	return 0;
+free_ipc:
+	la9310_free_dma_buf(la9310_dev->dev, "VSPA DMEM Proxy Buffer", &la9310_dev->dmem_proxy, DMA_BIDIRECTIONAL);
 free_iqflood:
 	la9310_free_dma_buf(la9310_dev->dev, "IQ FLood Buffer", &la9310_dev->iqflood_region, DMA_BIDIRECTIONAL);
 out:
@@ -1039,6 +1043,10 @@ la9310_base_remove(struct la9310_dev *la9310_dev)
 #endif
     la9310_unmap_mem_regions(la9310_dev);
 
+	// la9310_free_dma_buf(la9310_dev->dev, "VSPA DMEM Proxy Buffer", &la9310_dev->dmem_proxy, DMA_BIDIRECTIONAL);
+	// la9310_free_dma_buf(la9310_dev->dev, "IQ FLood Buffer", &la9310_dev->iqflood_region, DMA_BIDIRECTIONAL);
+	// la9310_free_dma_buf(la9310_dev->dev, "IQ FLood Buffer", &la9310_dev->iqflood_region, DMA_BIDIRECTIONAL);
+	// la9310_free_dma_buf(la9310_dev->dev, "Scratch buffer", host_region, DMA_BIDIRECTIONAL);
 	// la9310_remove_sysfs(la9310_dev);
 
 	return 0;

--- a/drivers/linux/la9310_limesdr/la9310_ioctl.c
+++ b/drivers/linux/la9310_limesdr/la9310_ioctl.c
@@ -25,35 +25,59 @@ static int la9310_get_memory_layout(const struct la9310_dev* la9310_dev, struct 
     return 0;
 }
 
+void la9310_flush_cache(struct la9310_dev *la9310_dev, struct LA9310_IOCTL_flush_cache *m, dma_addr_t phys_addr)
+{
+	if (m->sync_to_cpu)
+		dma_sync_single_for_cpu(la9310_dev->dev, phys_addr + m->offset, m->size, m->dir);
+	else
+		dma_sync_single_for_device(la9310_dev->dev, phys_addr + m->offset, m->size, m->dir);
+}
+
 long la9310_ioctl(struct file *file, unsigned int cmd, unsigned long arg)
 {
-    long ret = 0;
+	long ret = 0;
 
-    struct la9310_dev *myDevice = file->private_data;
+	struct la9310_dev *la9310_dev = file->private_data;
+	struct LA9310_IOCTL_flush_cache cache_entry;
 
-    WARN_ON(myDevice == NULL);
+	WARN_ON(la9310_dev == NULL);
 
-    if (!myDevice)
-    {
-        return -ENODEV;
-    }
+	if (!la9310_dev)
+	{
+		return -ENODEV;
+	}
 
-    switch (cmd)
-    {
-    case LA9310_IOCTL_GET_MEMORY_LAYOUT: {
-        struct LA9310_IOCTL_memory_layout layout;
+	switch (cmd) {
+		case LA9310_IOCTL_GET_MEMORY_LAYOUT: {
+			struct LA9310_IOCTL_memory_layout layout;
 
-        ret = la9310_get_memory_layout(myDevice, &layout);
-        if (ret)
-            return ret;
+			ret = la9310_get_memory_layout(la9310_dev, &layout);
+			if (ret)
+				return ret;
 
-        if (copy_to_user((void*)arg, &layout, sizeof(struct LA9310_IOCTL_memory_layout)))
-            return -EFAULT;
+			if (copy_to_user((void*)arg, &layout, sizeof(struct LA9310_IOCTL_memory_layout)))
+				return -EFAULT;
 
-        break;
-    }
-    default:
-        return -ENOTTY;
-    }
-    return ret;
+			break;
+		}
+		case LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM:
+			if (copy_from_user(&cache_entry, (void *) arg, sizeof(struct LA9310_IOCTL_flush_cache)))
+				return -EFAULT;
+
+			cache_entry.dir = DMA_BIDIRECTIONAL;
+			la9310_flush_cache(la9310_dev, &cache_entry, la9310_dev->dmem_proxy.phys_addr);
+			ret = 0;
+			break;
+		case LA9310_IOCTL_FLUSH_CACHE_IQFLOOD:
+			if (copy_from_user(&cache_entry, (void *) arg, sizeof(struct LA9310_IOCTL_flush_cache)))
+				return -EFAULT;
+
+			cache_entry.dir = DMA_BIDIRECTIONAL;
+			la9310_flush_cache(la9310_dev, &cache_entry, la9310_dev->iqflood_region.phys_addr);
+			ret = 0;
+			break;
+		default:
+		     return -ENOTTY;
+	}
+	return ret;
 }

--- a/drivers/linux/la9310_limesdr/la9310_ioctl.h
+++ b/drivers/linux/la9310_limesdr/la9310_ioctl.h
@@ -6,6 +6,13 @@ struct LA9310_IOCTL_firmware {
     uint32_t size;
 };
 
+struct LA9310_IOCTL_flush_cache {
+	uint32_t offset;
+	uint32_t size;
+	uint8_t dir;
+	uint8_t sync_to_cpu;
+};
+
 typedef enum {
     LA9310_WINDOW_BAR0,
     LA9310_WINDOW_BAR1,
@@ -32,6 +39,8 @@ struct LA9310_IOCTL_memory_layout {
 #define LA9310_IOCTL 'S'
 
 #define LA9310_IOCTL_GET_MEMORY_LAYOUT _IOR(LA9310_IOCTL, 25, struct LA9310_IOCTL_memory_layout)
+#define LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM _IOR(LA9310_IOCTL, 26, struct LA9310_IOCTL_flush_cache)
+#define LA9310_IOCTL_FLUSH_CACHE_IQFLOOD _IOR(LA9310_IOCTL, 27, struct LA9310_IOCTL_flush_cache)
 
 long la9310_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
 

--- a/drivers/linux/la9310_limesdr/la9310_limesdr_device.c
+++ b/drivers/linux/la9310_limesdr/la9310_limesdr_device.c
@@ -25,7 +25,7 @@ int la9310_limesdr_device_init(struct la9310_dev *la9310, struct pci_dev *pciCon
 
     void *drvdata = la9310;
     struct device *trxDev = device_create(la9310_limesdr_class, sysDev, cdev_major_minor, drvdata, "%s", cdev_name);
-    if (trxDev == ERR_PTR)
+    if (IS_ERR(trxDev))
     {
         dev_err(sysDev, "Failed to create device\n");
         la9310_cdev_destroy(la9310);

--- a/src/chips/LA9310/VSPA_iqplayer.cpp
+++ b/src/chips/LA9310/VSPA_iqplayer.cpp
@@ -102,6 +102,10 @@ VSPA_iqplayer::VSPA_iqplayer(std::shared_ptr<LA9310_PCIe> port)
     void* tx_proxy_wo = nullptr;
     void* rx_proxy_wo = nullptr;
     uint8_t* BAR2_addr = reinterpret_cast<uint8_t*>(v_la9310_bar2.vaddr);
+
+    auto nv_tx_vspa_proxy_ro = const_cast<t_tx_ch_host_proxy *>(tx_vspa_proxy_ro);
+    port->sync_dmem_proxy_after_write(reinterpret_cast<uint8_t *>(nv_tx_vspa_proxy_ro), sizeof(t_tx_ch_host_proxy));
+
     if (tx_vspa_proxy_ro->rx_num_chan == 1)
     {
         tx_proxy_wo = BAR2_addr + 0x400000 + 0x00000000;
@@ -328,6 +332,8 @@ OpStatus VSPA_iqplayer::SetupRx(uint32_t channel, uint32_t fifo_start_offset, ui
         return OpStatus::InvalidValue;
 
     // dccivac((uint32_t*)(rx_vspa_proxy_ro));
+    auto nv_rx_vspa_proxy_ro = const_cast<t_rx_ch_host_proxy *>(rx_vspa_proxy_ro);
+    port->sync_dmem_proxy_before_read(reinterpret_cast<uint8_t *>(nv_rx_vspa_proxy_ro), sizeof(t_rx_ch_host_proxy));
 
     // init fifo pointers
     rxState.fifo_start_addr = fifo_start_offset;
@@ -346,10 +352,13 @@ OpStatus VSPA_iqplayer::SetupRx(uint32_t channel, uint32_t fifo_start_offset, ui
 
     auto ddr_dst = vl_iqflood_ddr_addr + rxState.fifo_start_addr;
     memset(ddr_dst, 0, rxState.fifo_size); // clear RAM, not to confuse with old data from previous runs
+    
     // complex16_t* ps = reinterpret_cast<complex16_t*>(ddr_dst);
     // for (size_t i = 0; i < rxState.fifo_size / sizeof(complex16_t); ++i)
     //     ps[i] = complex16_t(32000 + (i % 512), -32020 + (i % 512));
 
+    auto nv_app_stats = const_cast<t_stats *>(app_stats);
+    port->sync_dmem_proxy_after_write(reinterpret_cast<uint8_t *>(nv_app_stats), sizeof(t_stats));
     return OpStatus::Success;
 }
 
@@ -364,6 +373,8 @@ OpStatus VSPA_iqplayer::SetupTx(uint32_t fifo_start_offset, uint32_t fifo_size)
         return OpStatus::InvalidValue;
 
     // dccivac((uint32_t*)(tx_vspa_proxy_ro));
+    auto nv_tx_vspa_proxy_ro = const_cast<t_tx_ch_host_proxy *>(tx_vspa_proxy_ro);
+    port->sync_dmem_proxy_before_read(reinterpret_cast<uint8_t *>(nv_tx_vspa_proxy_ro), sizeof(t_tx_ch_host_proxy));
 
     /* check firmware is idle waiting for new data */
     //if (tx_vspa_proxy_ro->host_produced_size != tx_vspa_proxy_ro->la9310_fifo_enqueued_size) {
@@ -381,6 +392,7 @@ OpStatus VSPA_iqplayer::SetupTx(uint32_t fifo_start_offset, uint32_t fifo_size)
 
     auto ddr_dst = vl_iqflood_ddr_addr + txState.fifo_start_addr;
     memset(ddr_dst, 0, txState.fifo_size);
+    port->sync_iq_flood_after_write(ddr_dst, txState.fifo_size);
 
     // complex16_t* ps = reinterpret_cast<complex16_t*>(ddr_dst);
     // for (int i = 0; i < txState.fifo_size / sizeof(complex16_t); ++i)
@@ -395,6 +407,9 @@ OpStatus VSPA_iqplayer::SetupTx(uint32_t fifo_start_offset, uint32_t fifo_size)
     app_stats->tx_stats[STAT_EXT_DMA_DDR_RD] = 0;
     app_stats->tx_stats[STAT_APP_DDR_RD] = 0;
 
+    auto nv_app_stats = const_cast<t_stats *>(app_stats);
+    port->sync_dmem_proxy_after_write(reinterpret_cast<uint8_t *>(nv_app_stats), sizeof(t_stats));
+
     return OpStatus::Success;
 }
 
@@ -404,6 +419,8 @@ int32_t VSPA_iqplayer::Receive(uint32_t channel, uint32_t* destination, uint32_t
     VSPA_FIFO_State& rxState = mRx[channel];
 
     // dccivac((uint32_t*)(rx_vspa_proxy_ro));
+    auto nv_rx_vspa_proxy_ro = const_cast<t_rx_ch_host_proxy *>(rx_vspa_proxy_ro);
+    port->sync_dmem_proxy_before_read(reinterpret_cast<uint8_t *>(nv_rx_vspa_proxy_ro), sizeof(t_rx_ch_host_proxy));
 
     // Check new transfer
     const uint32_t dev_produced = rx_vspa_proxy_ro[channel].la9310_fifo_consumed_size;
@@ -454,9 +471,14 @@ int32_t VSPA_iqplayer::Receive(uint32_t channel, uint32_t* destination, uint32_t
     rxState.bytes_consumed += data_size;
     app_stats->rx_stats[channel][STAT_APP_DDR_WR] = rxState.bytes_consumed / rx_ddr_step;
 
+    auto nv_app_stats = const_cast<t_stats *>(app_stats);
+    port->sync_dmem_proxy_after_write(reinterpret_cast<uint8_t *>(nv_app_stats), sizeof(t_stats));
+
     // xfer data
     volatile auto ddr_src = vl_iqflood_ddr_addr + rxState.fifo_start_addr + rxState.fifo_offset;
+    port->sync_iq_flood_before_read(ddr_src, data_size);
     memcpy(destination, ddr_src, data_size);
+
 
     // complex16_t* ps = reinterpret_cast<complex16_t*>(ddr_src);
     // for (int i = 0; i < data_size / sizeof(complex16_t); ++i)
@@ -476,6 +498,9 @@ int32_t VSPA_iqplayer::Transmit(const void* src, uint32_t write_size, uint64_t t
 {
     // const std::lock_guard<std::mutex> lock(mx);
     volatile VSPA_FIFO_State& txState = mTx;
+
+    auto nv_tx_vspa_proxy_ro = const_cast<t_tx_ch_host_proxy *>(tx_vspa_proxy_ro);
+    port->sync_dmem_proxy_before_read(reinterpret_cast<uint8_t *>(nv_tx_vspa_proxy_ro), sizeof(t_tx_ch_host_proxy));
 
     // Check new transfer opty
     txState.bytes_consumed = tx_vspa_proxy_ro->la9310_fifo_enqueued_size;
@@ -511,12 +536,16 @@ int32_t VSPA_iqplayer::Transmit(const void* src, uint32_t write_size, uint64_t t
     // xfer data
     auto ddr_dst = vl_iqflood_ddr_addr + txState.fifo_start_addr + txState.fifo_offset;
     memcpy(ddr_dst, src, write_size);
+    port->sync_iq_flood_after_write(ddr_dst, write_size);
     //flush_region(ddr_dst, empty_size);
 
     // ready to send new data
     txState.bytes_produced += write_size;
     tx_vspa_proxy_wo->host_produced_size = txState.bytes_produced;
     app_stats->tx_stats[STAT_APP_DDR_RD] = txState.bytes_produced / tx_ddr_step;
+
+    auto nv_app_stats = const_cast<t_stats *>(app_stats);
+    port->sync_dmem_proxy_after_write(reinterpret_cast<uint8_t *>(nv_app_stats), sizeof(t_stats));
 
     txState.fifo_offset += write_size;
     if (txState.fifo_offset >= txState.fifo_size)

--- a/src/comms/PCIe/LA9310_PCIe.cpp
+++ b/src/comms/PCIe/LA9310_PCIe.cpp
@@ -20,6 +20,16 @@
     #include <sys/ioctl.h>
 #endif
 
+#if 0 // print debug messages
+    #define printf_dbg_log(...) \
+        do \
+        { \
+            printf(__VA_ARGS__); \
+        } while (0)
+#else
+    #define printf_dbg_log(format, ...)
+#endif
+
 using namespace std;
 using namespace lime;
 using namespace std::literals::string_literals;
@@ -157,4 +167,68 @@ int LA9310_PCIe::ReadControl(uint8_t* buffer, const int length, int timeout_ms)
 mmaped_region LA9310_PCIe::GetBar(uint8_t i)
 {
     return mapped_ranges[i];
+}
+
+void LA9310_PCIe::sync_dmem_proxy_before_read(uint8_t *addr, uint32_t data_size)
+{
+       struct LA9310_IOCTL_flush_cache cache_entry;
+       auto vl_dmem_proxy_addr = mapped_ranges[LA9310_WINDOW_IPC].vaddr;
+
+       // Fill struct with information
+       cache_entry.sync_to_cpu = 1;
+       cache_entry.size = data_size;
+       cache_entry.offset = static_cast<uint32_t>(addr - static_cast<uint8_t*>(vl_dmem_proxy_addr));
+
+       printf_dbg_log("sync_dmem_proxy_before_read called for offset: 0x%08x\n", cache_entry.offset);
+
+       // Fire ioctl
+       ioctl(mFileDescriptor, LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM, &cache_entry);
+}
+
+void LA9310_PCIe::sync_dmem_proxy_after_write(uint8_t *addr, uint32_t data_size)
+{
+       struct LA9310_IOCTL_flush_cache cache_entry;
+       auto vl_dmem_proxy_addr = mapped_ranges[LA9310_WINDOW_IPC].vaddr;
+
+       // Fill struct with information
+       cache_entry.sync_to_cpu = 0;
+       cache_entry.size = data_size;
+       cache_entry.offset = static_cast<uint32_t>(addr - static_cast<uint8_t*>(vl_dmem_proxy_addr));
+
+       printf_dbg_log("sync_dmem_proxy_after_write called for offset: 0x%08x\n", cache_entry.offset);
+
+       // Fire ioctl
+       ioctl(mFileDescriptor, LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM, &cache_entry);
+}
+
+void LA9310_PCIe::sync_iq_flood_before_read(uint8_t *addr, uint32_t data_size)
+{
+       struct LA9310_IOCTL_flush_cache cache_entry;
+       auto vl_iqflood_ddr_addr = mapped_ranges[LA9310_WINDOW_IQFLOOD].vaddr;
+
+       // Fill struct with information
+       cache_entry.sync_to_cpu = 1;
+       cache_entry.size = data_size;
+       cache_entry.offset = static_cast<uint32_t>(addr - static_cast<uint8_t*>(vl_iqflood_ddr_addr));
+
+       printf_dbg_log("sync_iq_flood_before_read called for offset: 0x%08x\n", cache_entry.offset);
+
+       // Fire ioctl
+       ioctl(mFileDescriptor, LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM, &cache_entry);
+}
+
+void LA9310_PCIe::sync_iq_flood_after_write(uint8_t *addr, uint32_t data_size)
+{
+       struct LA9310_IOCTL_flush_cache cache_entry;
+       auto vl_iqflood_ddr_addr = mapped_ranges[LA9310_WINDOW_IQFLOOD].vaddr;
+
+       // Fill struct with information
+       cache_entry.sync_to_cpu = 0;
+       cache_entry.size = data_size;
+       cache_entry.offset = static_cast<uint32_t>(addr - static_cast<uint8_t*>(vl_iqflood_ddr_addr));
+
+       printf_dbg_log("sync_iq_flood_after_write called for offset: 0x%08x\n", cache_entry.offset);
+
+       // Fire ioctl
+       ioctl(mFileDescriptor, LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM, &cache_entry);
 }

--- a/src/comms/PCIe/LA9310_PCIe.h
+++ b/src/comms/PCIe/LA9310_PCIe.h
@@ -56,6 +56,27 @@ class LIME_API LA9310_PCIe : public LimePCIe
     virtual int ReadControl(uint8_t* buffer, int length, int timeout_ms = 100);
     virtual OpStatus RunControlCommand(uint8_t* data, size_t length, int timeout_ms = 100);
     virtual OpStatus RunControlCommand(uint8_t* request, uint8_t* response, size_t length, int timeout_ms = 100);
+    // Methods for cache coherency
+
+    /// @brief Clean & invalidate cache for DMEM Proxy before a read access
+    /// @param pointer to address to sync
+    /// @param data size to sync
+    void sync_dmem_proxy_before_read(uint8_t *addr, uint32_t data_size);
+
+    /// @brief Clean & invalidate cache for DMEM Proxy after a write access
+    /// @param pointer to address to sync
+    /// @param data size to sync
+    void sync_dmem_proxy_after_write(uint8_t *addr, uint32_t data_size);
+
+    /// @brief Clean & invalidate cache for IQ Flood before a read access
+    /// @param pointer to address to sync
+    /// @param data size to sync
+    void sync_iq_flood_before_read(uint8_t *addr, uint32_t data_size);
+
+    /// @brief Clean & invalidate cache for IQ Flood after a write access
+    /// @param pointer to address to sync
+    /// @param data size to sync
+    void sync_iq_flood_after_write(uint8_t *addr, uint32_t data_size);
 
     mmaped_region GetBar(uint8_t i);
 


### PR DESCRIPTION
    - added functions for allocating and mapping dma buffer
    - added functions for freeing and unmapping dma buffer
    - increase indent consistencies in edited functions (4 spaces <-> tab)
    - removed compiler warning in la9310_limesdr_device.c
    - Added ioctl for syncing IQ FLood and IPC DRAM areas
    - integrate the ioctl's in VSPA Player app