### PR TITLE
limeTRX: fix transmitting samples from large files

### DIFF
--- a/cli/limeTRX.cpp
+++ b/cli/limeTRX.cpp
@@ -296,7 +296,7 @@ static void TransmitLoop(TransmitLoopArgs* args)
     assert(fin);
 
     fin->seekg(0, fin->end);
-    int fileSize = fin->tellg();
+    std::streamoff fileSize = (std::streamoff)fin->tellg();
     fin->seekg(0, fin->beg);
 
     const int64_t txSamplesCountTotal = fileSize / sizeof(complex16_t) / args->channelCount;
@@ -323,7 +323,7 @@ static void TransmitLoop(TransmitLoopArgs* args)
 
     do
     {
-        int samplesRemaining = txSamplesCountTotal;
+        int64_t samplesRemaining = txSamplesCountTotal;
         txMeta.flags = 0;
         while (samplesRemaining > 0 && args->terminate->load(std::memory_order_relaxed) == false)
         {


### PR DESCRIPTION
Using the narrow int type to store the file size caused limeTRX to stop transmitting samples when the waveform file exceeded 2 GB [1].

Replace the fileSize type with std::streamoff and widen samplesRemaining to int64_t to correctly handle large files.

[1]
$ LimeTRX -d 0 --input=LargeFile.iqs --linkFormat=I16 --looptx --mimo=1 Tx file size : -573571072 bytes.
Samples received: 16384
...