### PR TITLE
Added ioctls for FW loading

### DIFF
--- a/drivers/linux/la9310_limesdr/la9310_base.c
+++ b/drivers/linux/la9310_limesdr/la9310_base.c
@@ -788,6 +788,11 @@ int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char __user *fw
 {
 	int rc;
 
+	if (la9310_dev->arm_m4_fw_loaded) {
+		dev_err(la9310_dev->dev, "Firmware for ARM M4 is already loaded!\n");
+		return -EBUSY;
+	}
+
 	dev_info(la9310_dev->dev, "Loading RTOS image\n");
 	rc = la9310_load_rtos_img(la9310_dev, fw_data, fw_length);
 	if (rc)	{
@@ -837,7 +842,8 @@ int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char __user *fw
 	rc = la9310_subdrv_init(la9310_dev);
 	if (rc)
 		goto free_msi_irq;
-
+	
+	la9310_dev->arm_m4_fw_loaded = 1;
 	return 0;
 
 free_msi_irq:

--- a/drivers/linux/la9310_limesdr/la9310_base.c
+++ b/drivers/linux/la9310_limesdr/la9310_base.c
@@ -743,185 +743,6 @@ static void la9310_init_msg_unit_ptrs(struct la9310_dev* la9310_dev)
         la9310_dev->msg_units[i] = msg_unit + i;
 }
 
-int la9310_base_probe(struct la9310_dev* la9310_dev)
-{
-    int i = 0, rc = 0, virq_count, init_stage = 0;
-    struct la9310_sub_driver* subdrv;
-    struct la9310_sub_driver_ops* ops;
-    struct virq_evt_map subdrv_virqmap[IRQ_REAL_MSI_BIT];
-    struct virq_evt_map* subdrv_virqmap_ptr;
-    u32 pci_abserr;
-    struct la9310_mem_region_info* ccsr_region;
-    // struct device_node *np;
-    // struct resource mem_addr;
-
-    la9310_dev->stats_control = LA9310_STATS_DEFAULT_ENABLE_MASK;
-
-    init_stage = LA9310_SCRATCH_DMA_INIT_STAGE;
-    rc = la9310_scratch_dma_buf(la9310_dev);
-    if (rc)
-    {
-        dev_err(la9310_dev->dev, "Failed to init DMA buf for outbound, err %d\n", rc);
-        goto out;
-    }
-
-    la9310_dev->iq_mem_size = 4 * 1024 * 1024;
-
-    rc = la9310_alloc_dma_buf(
-        la9310_dev->dev, "IQ Flood Buffer", &la9310_dev->iqflood_region, la9310_dev->iq_mem_size, DMA_BIDIRECTIONAL);
-    if (rc)
-        goto out;
-    la9310_dev->iq_mem_addr = la9310_dev->iqflood_region.phys_addr;
-
-    la9310_create_rfnm_iqflood_outbound(la9310_dev);
-    rc = la9310_alloc_dma_buf(
-        la9310_dev->dev, "VSPA DMEM Proxy Buffer", &la9310_dev->dmem_proxy, VSPA_DMEM_PROXY_SIZE, DMA_BIDIRECTIONAL);
-    if (rc)
-        goto free_iqflood;
-
-    la9310_create_ipc_outbound(la9310_dev);
-
-    rc = la9310_init_hif(la9310_dev);
-    if (rc)
-        goto free_ipc;
-    la9310_init_msg_unit_ptrs(la9310_dev);
-    la9310_init_ep_logger(la9310_dev);
-
-    // rc = la9310_init_sysfs(la9310_dev);
-    // if (rc)
-    // 	goto free_ipc;
-    init_stage = LA9310_SYSFS_INIT_STAGE;
-
-    // rc = la9310_register_ep_stats_ops(la9310_dev);
-    // if (rc)
-    // 	goto free_ipc;
-
-    dev_info(la9310_dev->dev, "%s: Loading RTOS image\n", la9310_dev->name);
-    rc = la9310_load_rtos_img(la9310_dev);
-    if (rc)
-    {
-        dev_err(la9310_dev->dev, "Failed to add RTOS image, err %d", rc);
-        goto free_ipc;
-    }
-
-#ifndef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
-    rc = la9310_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
-    if (rc)
-    {
-        pr_err("%s: probe irq req failed, err %d\n", __func__, rc);
-        goto free_ipc;
-    }
-
-    /*scrach register handshake request irq */
-    init_completion(&ScratchRegisterHandshake);
-    rc = request_irq(
-        la9310_get_msi_irq(la9310_dev, MSI_IRQ_HOST_HANDSHAKE), host_handshake_handler, 0, "Host Handshake interrupt", la9310_dev);
-
-#endif
-    init_stage = LA9310_HANDSHAKE_INIT_STAGE;
-    dev_info(la9310_dev->dev, "%s: Initiating Reset handshake\n", la9310_dev->name);
-    rc = la9310_do_reset_handshake(la9310_dev);
-    if (rc)
-    {
-        dev_err(la9310_dev->dev, "Reset handshake failed, err %d", rc);
-        goto free_ipc;
-    }
-
-    /* Verify that Host and target are using same version of HIF */
-    rc = la9310_verify_hif_compatibility(la9310_dev);
-    if (rc)
-        goto free_ipc;
-
-    init_stage = LA9310_IRQ_INIT_STAGE;
-#ifdef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
-    rc = la9310_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
-    if (rc)
-    {
-        pr_err("%s: probe irq req failed, err %d\n", __func__, rc);
-        goto free_ipc;
-    }
-#endif
-    /* WDOG request_irq */
-    // wdog_msi_irq = la9310_get_msi_irq(la9310_dev, MSI_IRQ_WDOG);
-    /* Errata A-008822 */
-    pci_abserr = PCIE_RHOM_DBI_BASE + PCIE_ABSERR;
-    ccsr_region = &la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR];
-    writel(PCIE_ABSERR_SETTING, ccsr_region->vaddr + pci_abserr);
-    // wdog_set_pci_domain_nr(la9310_dev->id,
-    // 		pci_domain_nr(la9310_dev->pdev->bus));
-    // wdog_set_modem_status(0, WDOG_MODEM_READY);
-
-    writel(la9310_dev->adc_mask, &la9310_dev->hif->adc_mask);
-    writel(la9310_dev->adc_rate_mask, &la9310_dev->hif->adc_rate_mask);
-    writel(la9310_dev->dac_mask, &la9310_dev->hif->dac_mask);
-    writel(la9310_dev->dac_rate_mask, &la9310_dev->hif->dac_rate_mask);
-
-    writel(LA9310_IQFLOOD_PHYS_ADDR, &la9310_dev->hif->iq_phys_addr);
-    writel(la9310_dev->iq_mem_size, &la9310_dev->hif->iq_mem_size);
-    writel(la9310_dev->iq_mem_addr, &la9310_dev->hif->iq_mem_addr);
-    writel(la9310_dev->modem_rf_data_size, &la9310_dev->hif->modem_rf_data_size);
-
-    init_stage = LA9310_SUBDRV_PROBE_STAGE;
-    dev_info(la9310_dev->dev, "%s:Initiating sub-drivers\n", la9310_dev->name);
-    for (i = 0; i < la9310_subdrv_cnt_g; i++)
-    {
-        subdrv = la9310_get_subdrv(i);
-        ops = &subdrv->ops;
-        if (ops->probe)
-        {
-            pr_info("%s: subdrv probe : %s\n", __func__, &subdrv->name[0]);
-
-            memset(&subdrv_virqmap[0], 0, sizeof(subdrv_virqmap));
-            virq_count = la9310_get_subdrv_virqmap(la9310_dev, subdrv, &subdrv_virqmap[0], IRQ_REAL_MSI_BIT);
-            if (virq_count)
-                subdrv_virqmap_ptr = &subdrv_virqmap[0];
-            else
-                subdrv_virqmap_ptr = NULL;
-            rc = ops->probe(la9310_dev, virq_count, subdrv_virqmap_ptr);
-            if (rc)
-            {
-                pr_err("%s: %s: probe failed, err %d\n", __func__, &subdrv->name[0], rc);
-                goto free_ipc;
-            }
-        }
-    }
-    la9310_init_ep_pcie_allocator(la9310_dev);
-    // rc = la9310_modinfo_init(la9310_dev);
-
-    struct resource* tty_res = NULL;
-    tty_res = devm_kzalloc(la9310_dev->dev, sizeof(struct resource), GFP_KERNEL);
-    if (!tty_res)
-    {
-        dev_err(la9310_dev->dev, "Failed to allocate memory for UART\n");
-        rc = -1;
-        goto free_ipc;
-    }
-    {
-        tty_res->start = (resource_size_t)la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR].vaddr + 0x21c0000;
-    }
-    tty_res->flags = IORESOURCE_REG;
-    char* devSymlink = devm_kzalloc(la9310_dev->dev, 64, GFP_KERNEL);
-    snprintf(devSymlink, 64, "limesdr_micro_uart");
-    tty_res->name = devSymlink;
-    la9310_dev->uart = platform_device_register_simple("la9310uart", 1, tty_res, 1);
-    if (IS_ERR(la9310_dev->uart))
-    {
-        dev_err(la9310_dev->dev, "Failed to register UART\n");
-        rc = -1;
-        goto free_ipc;
-    }
-
-    return 0;
-free_ipc:
-    la9310_free_dma_buf(la9310_dev->dev, "VSPA DMEM Proxy Buffer", &la9310_dev->dmem_proxy, DMA_BIDIRECTIONAL);
-free_iqflood:
-    la9310_free_dma_buf(la9310_dev->dev, "IQ FLood Buffer", &la9310_dev->iqflood_region, DMA_BIDIRECTIONAL);
-out:
-    if (rc)
-        la9310_base_deinit(la9310_dev, init_stage, i);
-    return rc;
-}
-
 static int la9310_base_cleanup_subdrv(struct la9310_dev* la9310_dev, int drv_index)
 {
     int i = 0, rc = 0;
@@ -945,6 +766,223 @@ static int la9310_base_cleanup_subdrv(struct la9310_dev* la9310_dev, int drv_ind
             }
         }
     }
+    return rc;
+}
+
+static int la9310_subdrv_init(struct la9310_dev *la9310_dev)
+{
+	int i, virq_count, rc;
+	struct la9310_sub_driver* subdrv;
+	struct la9310_sub_driver_ops* ops;
+	struct virq_evt_map subdrv_virqmap[IRQ_REAL_MSI_BIT];
+	struct virq_evt_map* subdrv_virqmap_ptr;
+
+	dev_info(la9310_dev->dev, "%s: Initiating sub-drivers\n", la9310_dev->name);
+	for (i = 0; i < la9310_subdrv_cnt_g; i++) {
+		subdrv = la9310_get_subdrv(i);
+		ops = &subdrv->ops;
+		if (ops->probe) {
+			pr_info("%s: subdrv probe : %s\n", __func__, &subdrv->name[0]);
+
+			memset(&subdrv_virqmap[0], 0, sizeof(subdrv_virqmap));
+			virq_count = la9310_get_subdrv_virqmap(la9310_dev, subdrv, &subdrv_virqmap[0], IRQ_REAL_MSI_BIT);
+			if (virq_count)
+				subdrv_virqmap_ptr = &subdrv_virqmap[0];
+			else
+				subdrv_virqmap_ptr = NULL;
+			rc = ops->probe(la9310_dev, virq_count, subdrv_virqmap_ptr);
+			if (rc) {
+				pr_err("%s: %s: probe failed, err %d\n", __func__, &subdrv->name[0], rc);
+				goto free_subdrv;
+			}
+		}
+	}
+
+	return 0;
+free_subdrv:
+        la9310_base_cleanup_subdrv(la9310_dev, i);
+	return rc;
+}
+
+int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char *m4_fw_name)
+{
+	int rc;
+
+	strncpy(la9310_dev->firmware_name, m4_fw_name, sizeof(la9310_dev->firmware_name));
+	dev_info(la9310_dev->dev, "%s: Loading RTOS image\n", la9310_dev->name);
+	rc = la9310_load_rtos_img(la9310_dev);
+	if (rc)	{
+		dev_err(la9310_dev->dev, "Failed to add RTOS image, err %d", rc);
+		return rc;
+	}
+
+#ifndef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
+	rc = la9310_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
+	if (rc)
+	{
+		dev_err(la9310_dev->dev, "%s: probe irq req failed, err %d\n", __func__, rc);
+		return rc;
+	}
+
+	/* scrach register handshake request irq */
+	init_completion(&ScratchRegisterHandshake);
+	rc = request_irq(
+			la9310_get_msi_irq(la9310_dev, MSI_IRQ_HOST_HANDSHAKE), host_handshake_handler, 0, "Host Handshake interrupt", la9310_dev);
+	if (rc) {
+		dev_err(la9310_dev->dev, "%s: request_irq failed, err %d\n", __func__, rc);
+		goto free_hs_irq;
+	}
+
+#endif
+	dev_info(la9310_dev->dev, "%s: Initiating Reset handshake\n", la9310_dev->name);
+	rc = la9310_do_reset_handshake(la9310_dev);
+	if (rc)
+	{
+		dev_err(la9310_dev->dev, "Reset handshake failed, err %d", rc);
+		goto free_msi_irq;
+	}
+
+	/* Verify that Host and target are using same version of HIF */
+	rc = la9310_verify_hif_compatibility(la9310_dev);
+	if (rc)
+		goto free_msi_irq;
+
+#ifdef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
+	rc = la9310_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
+	if (rc)	{
+		pr_err("%s: probe irq req failed, err %d\n", __func__, rc);
+		goto free_msi_irq;
+	}
+#endif
+
+	rc = la9310_subdrv_init(la9310_dev);
+	if (rc)
+		goto free_msi_irq;
+
+	return 0;
+
+free_msi_irq:
+#ifdef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
+	free_irq(la9310_get_msi_irq(la9310_dev, MSI_IRQ_HOST_HANDSHAKE), la9310_dev);
+free_hs_irq:
+	la9310_clean_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
+	free_irq(la9310_get_msi_irq(la9310_dev, MSI_IRQ_MUX), la9310_dev);
+#endif
+	return rc;
+}
+
+int la9310_base_probe(struct la9310_dev* la9310_dev)
+{
+    int rc = 0;
+    u32 pci_abserr;
+    struct la9310_mem_region_info* ccsr_region;
+    // struct device_node *np;
+    // struct resource mem_addr;
+
+    la9310_dev->stats_control = LA9310_STATS_DEFAULT_ENABLE_MASK;
+
+    rc = la9310_scratch_dma_buf(la9310_dev);
+    if (rc)
+    {
+        dev_err(la9310_dev->dev, "Failed to init DMA buf for outbound, err %d\n", rc);
+	return rc;
+    }
+
+    la9310_dev->iq_mem_size = 4 * 1024 * 1024;
+
+    rc = la9310_alloc_dma_buf(
+        la9310_dev->dev, "IQ Flood Buffer", &la9310_dev->iqflood_region, la9310_dev->iq_mem_size, DMA_BIDIRECTIONAL);
+    if (rc)
+        return rc;
+    la9310_dev->iq_mem_addr = la9310_dev->iqflood_region.phys_addr;
+
+    la9310_create_rfnm_iqflood_outbound(la9310_dev);
+    rc = la9310_alloc_dma_buf(
+        la9310_dev->dev, "VSPA DMEM Proxy Buffer", &la9310_dev->dmem_proxy, VSPA_DMEM_PROXY_SIZE, DMA_BIDIRECTIONAL);
+    if (rc)
+        goto free_iqflood;
+
+    la9310_create_ipc_outbound(la9310_dev);
+
+    rc = la9310_init_hif(la9310_dev);
+    if (rc)
+        goto free_ipc;
+    la9310_init_msg_unit_ptrs(la9310_dev);
+    la9310_init_ep_logger(la9310_dev);
+
+    // rc = la9310_init_sysfs(la9310_dev);
+    // if (rc)
+    // 	goto free_ipc;
+
+    // rc = la9310_register_ep_stats_ops(la9310_dev);
+    // if (rc)
+    // 	goto free_ipc;
+
+//    rc = la9310_load_m4_firmware(la9310_dev, "la9310.bin");
+//    if (rc)
+//	    goto free_ipc;
+
+    /* WDOG request_irq */
+    // wdog_msi_irq = la9310_get_msi_irq(la9310_dev, MSI_IRQ_WDOG);
+    /* Errata A-008822 */
+    pci_abserr = PCIE_RHOM_DBI_BASE + PCIE_ABSERR;
+    ccsr_region = &la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR];
+    writel(PCIE_ABSERR_SETTING, ccsr_region->vaddr + pci_abserr);
+    // wdog_set_pci_domain_nr(la9310_dev->id,
+    // 		pci_domain_nr(la9310_dev->pdev->bus));
+    // wdog_set_modem_status(0, WDOG_MODEM_READY);
+
+    writel(la9310_dev->adc_mask, &la9310_dev->hif->adc_mask);
+    writel(la9310_dev->adc_rate_mask, &la9310_dev->hif->adc_rate_mask);
+    writel(la9310_dev->dac_mask, &la9310_dev->hif->dac_mask);
+    writel(la9310_dev->dac_rate_mask, &la9310_dev->hif->dac_rate_mask);
+
+    writel(LA9310_IQFLOOD_PHYS_ADDR, &la9310_dev->hif->iq_phys_addr);
+    writel(la9310_dev->iq_mem_size, &la9310_dev->hif->iq_mem_size);
+    writel(la9310_dev->iq_mem_addr, &la9310_dev->hif->iq_mem_addr);
+    writel(la9310_dev->modem_rf_data_size, &la9310_dev->hif->modem_rf_data_size);
+
+    la9310_init_ep_pcie_allocator(la9310_dev);
+    // rc = la9310_modinfo_init(la9310_dev);
+
+    struct resource* tty_res = NULL;
+    tty_res = devm_kzalloc(la9310_dev->dev, sizeof(struct resource), GFP_KERNEL);
+    if (!tty_res)
+    {
+        dev_err(la9310_dev->dev, "Failed to allocate memory for UART\n");
+        rc = -1;
+        goto free_la_irq;;
+    }
+    {
+        tty_res->start = (resource_size_t)la9310_dev->mem_regions[LA9310_MEM_REGION_CCSR].vaddr + 0x21c0000;
+    }
+    tty_res->flags = IORESOURCE_REG;
+    char* devSymlink = devm_kzalloc(la9310_dev->dev, 64, GFP_KERNEL);
+    snprintf(devSymlink, 64, "limesdr_micro_uart");
+    tty_res->name = devSymlink;
+    la9310_dev->uart = platform_device_register_simple("la9310uart", 1, tty_res, 1);
+    if (IS_ERR(la9310_dev->uart))
+    {
+        dev_err(la9310_dev->dev, "Failed to register UART\n");
+        rc = -1;
+        goto free_la_irq;;
+    }
+
+    return 0;
+
+free_la_irq:
+        la9310_clean_request_irq(la9310_dev, &la9310_dev->hif->irq_evt_regs);
+free_handshake:
+#ifndef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
+        free_irq(la9310_get_msi_irq(la9310_dev, MSI_IRQ_HOST_HANDSHAKE), la9310_dev);
+        free_irq(la9310_get_msi_irq(la9310_dev, MSI_IRQ_MUX), la9310_dev);
+#endif
+//free_sysfs:
+        // la9310_remove_sysfs(la9310_dev);
+free_ipc:
+    la9310_free_dma_buf(la9310_dev->dev, "VSPA DMEM Proxy Buffer", &la9310_dev->dmem_proxy, DMA_BIDIRECTIONAL);
+free_iqflood:
+    la9310_free_dma_buf(la9310_dev->dev, "IQ FLood Buffer", &la9310_dev->iqflood_region, DMA_BIDIRECTIONAL);
     return rc;
 }
 

--- a/drivers/linux/la9310_limesdr/la9310_base.c
+++ b/drivers/linux/la9310_limesdr/la9310_base.c
@@ -152,47 +152,27 @@ void la9310_dev_free_firmware(struct la9310_dev* la9310_dev)
  * return success. After you are done with using firmware call
  * la9310_dev_free_firmware
  */
-int la9310_udev_load_firmware(struct la9310_dev* la9310_dev, char* buf, int buff_sz, char* name)
+int la9310_load_firmware(struct la9310_dev *la9310_dev, char *buf, int buff_sz, const char __user *fw_data, size_t fw_size)
 {
-    int rc = 0, size;
-    struct la9310_firmware_info* fw_info = &la9310_dev->firmware_info;
+	struct la9310_firmware_info* fw_info = &la9310_dev->firmware_info;
+	int rc;
 
-    if (strlen(name) < FIRMWARE_NAME_SIZE)
-    {
-        strcpy(fw_info->name, name);
-    }
-    else
-    {
-        dev_err(la9310_dev->dev, "Invalid firmware name %s\n", name);
-        rc = -ENODEV;
-        goto out;
-    }
+	/* Copy firmware from userspace to DMA region */
+	if (buff_sz < fw_size) {
+		dev_err(la9310_dev->dev, "Insufficient fw buff %p: size %ld\n", fw_data, fw_size);
+		return -ENOBUFS;
+	}
 
-    rc = request_firmware(&fw_info->fw, name, la9310_dev->dev);
-    if (rc)
-    {
-        dev_err(la9310_dev->dev, "Failed to load %s, %d\n", name, rc);
-        goto out;
-    }
+	dev_info(la9310_dev->dev, "Copy fw to %px, size %ld\n", fw_data, fw_size);
+	rc = copy_from_user(buf, fw_data, fw_size);
 
-    size = fw_info->fw->size;
-    dev_info(la9310_dev->dev, "Downloaded f/w at 0x%px size: %d\n", fw_info->fw->data, size);
+	if (rc) {
+		dev_err(la9310_dev->dev, "Could only copy %ld of %ld bytes of firmware.\n", fw_size - rc, fw_size);
+		return -EIO;
+	}
+	la9310_dev->firmware_info.size = fw_size;
 
-    if (buff_sz < size)
-    {
-        dev_err(la9310_dev->dev, "Insufficient fw buff %p: siz %d\n", buf, size);
-        rc = -ENOBUFS;
-    }
-    else
-    {
-        dev_info(la9310_dev->dev, "Copy fw to %px, size %d\n", buf, size);
-        memcpy_toio(buf, fw_info->fw->data, size);
-        la9310_dev->firmware_info.size = size;
-    }
-
-    release_firmware(fw_info->fw);
-out:
-    return rc;
+	return 0;
 }
 
 static void ls_pcie_iatu_outbound_set(void __iomem* dbi, int idx, int type, u64 cpu_addr, u64 pci_addr, u32 size)
@@ -804,13 +784,12 @@ free_subdrv:
 	return rc;
 }
 
-int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char *m4_fw_name)
+int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char __user *fw_data, size_t fw_length)
 {
 	int rc;
 
-	strncpy(la9310_dev->firmware_name, m4_fw_name, sizeof(la9310_dev->firmware_name));
-	dev_info(la9310_dev->dev, "%s: Loading RTOS image\n", la9310_dev->name);
-	rc = la9310_load_rtos_img(la9310_dev);
+	dev_info(la9310_dev->dev, "Loading RTOS image\n");
+	rc = la9310_load_rtos_img(la9310_dev, fw_data, fw_length);
 	if (rc)	{
 		dev_err(la9310_dev->dev, "Failed to add RTOS image, err %d", rc);
 		return rc;

--- a/drivers/linux/la9310_limesdr/la9310_base.h
+++ b/drivers/linux/la9310_limesdr/la9310_base.h
@@ -430,6 +430,7 @@ void raise_msg_interrupt(struct la9310_dev* la9310_dev, uint32_t msg_unit_index,
 ssize_t la9310_show_global_status(char* buf);
 
 int la9310_modinfo_init(struct la9310_dev* dev);
+int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char *m4_fw_name);
 // int la9310_modinfo_exit(struct la9310_dev *dev);
 // void la9310_modinfo_get(struct la9310_dev *la9310_dev, modinfo_t *mi);
 #endif

--- a/drivers/linux/la9310_limesdr/la9310_base.h
+++ b/drivers/linux/la9310_limesdr/la9310_base.h
@@ -333,6 +333,9 @@ struct la9310_dev {
 
     struct la9310_mem_region_info dmem_proxy;
     struct platform_device* uart;
+
+    u8 arm_m4_fw_loaded;
+    u8 vspa_fw_loaded;
 };
 
 /*la9310_dev->flags*/

--- a/drivers/linux/la9310_limesdr/la9310_base.h
+++ b/drivers/linux/la9310_limesdr/la9310_base.h
@@ -393,13 +393,14 @@ extern void la9310_subdrv_mod_exit(void);
 
 void la9310_subdrv_remove(struct la9310_dev* la9310_dev);
 int la9310_base_deinit(struct la9310_dev* la9310_dev, int stage, int drv_index);
-int la9310_load_rtos_img(struct la9310_dev* la9310_dev);
+int la9310_load_rtos_img(struct la9310_dev* la9310_dev, const char __user *fw_data, size_t fw_length);
 int la9310_do_reset_handshake(struct la9310_dev* la9310_dev);
 void la9310_hexdump(const void* ptr, size_t sz);
 int la9310_map_mem_regions(struct la9310_dev* la9310_dev);
 void la9310_unmap_mem_regions(struct la9310_dev* la9310_dev);
 int la9310_base_probe(struct la9310_dev* la9310_dev);
 int la9310_base_remove(struct la9310_dev* la9310_dev);
+int la9310_load_firmware(struct la9310_dev *la9310_dev, char *buf, int buff_sz, const char __user *fw_data, size_t fw_size);
 int la9310_udev_load_firmware(struct la9310_dev* la9310_dev, char* buf, int buff_sz, char* name);
 struct la9310_mem_region_info* la9310_get_dma_region(struct la9310_dev* la9310_dev, enum la9310_mem_region_t type);
 int la9310_dev_reserve_firmware(struct la9310_dev* la9310_dev);
@@ -430,7 +431,7 @@ void raise_msg_interrupt(struct la9310_dev* la9310_dev, uint32_t msg_unit_index,
 ssize_t la9310_show_global_status(char* buf);
 
 int la9310_modinfo_init(struct la9310_dev* dev);
-int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char *m4_fw_name);
+int la9310_load_m4_firmware(struct la9310_dev *la9310_dev, const char __user *fw_data, size_t fw_length);
 // int la9310_modinfo_exit(struct la9310_dev *dev);
 // void la9310_modinfo_get(struct la9310_dev *la9310_dev, modinfo_t *mi);
 #endif

--- a/drivers/linux/la9310_limesdr/la9310_firmware.c
+++ b/drivers/linux/la9310_limesdr/la9310_firmware.c
@@ -11,24 +11,6 @@
 
 #define NXP_ERRATUM_A008822 1
 
-static int check_file(const char* filename)
-{
-    struct file* file;
-    char path[FIRMWARE_NAME_SIZE];
-
-    if (!filename || !*filename)
-        return -EINVAL;
-
-    sprintf(path, "/lib/firmware/%s", filename);
-
-    file = filp_open(path, O_RDONLY, 0);
-    if (IS_ERR(file))
-        return PTR_ERR(file);
-
-    fput(file);
-    return 0;
-}
-
 int la9310_do_reset_handshake(struct la9310_dev* la9310_dev)
 {
 #ifndef LA9310_RESET_HANDSHAKE_POLLING_ENABLE
@@ -110,7 +92,7 @@ int la9310_do_reset_handshake(struct la9310_dev* la9310_dev)
     return rc;
 }
 
-int la9310_load_rtos_img(struct la9310_dev* la9310_dev)
+int la9310_load_rtos_img(struct la9310_dev* la9310_dev, const char __user *fw_data, size_t fw_length)
 {
     int rc = 0, retries = LA9310_HOST_BOOT_HSHAKE_RETRIES;
     struct la9310_mem_region_info* tcm_region;
@@ -153,20 +135,14 @@ int la9310_load_rtos_img(struct la9310_dev* la9310_dev)
     rc = la9310_dev_reserve_firmware(la9310_dev);
     if (rc)
         goto out;
-    sprintf(freertos_img, "%s", la9310_dev->firmware_name);
-    rc = check_file(freertos_img);
-    if (rc)
-    {
-        dev_err(la9310_dev->dev, "FreeRTOS Image file(%s) not present", freertos_img);
-        goto out;
-    }
 
     dma_sync_single_for_cpu(
         la9310_dev->dev, la9310_dev->dma_info.host_buf.phys_addr, la9310_dev->dma_info.host_buf.size, DMA_BIDIRECTIONAL);
-    rc = la9310_udev_load_firmware(la9310_dev, dma_region->vaddr, size, freertos_img);
+    rc = la9310_load_firmware(la9310_dev, dma_region->vaddr, size, fw_data, fw_length);
     dma_sync_single_for_device(
         la9310_dev->dev, la9310_dev->dma_info.host_buf.phys_addr, la9310_dev->dma_info.host_buf.size, DMA_BIDIRECTIONAL);
     la9310_dev_free_firmware(la9310_dev);
+
     if (rc)
     {
         dev_err(la9310_dev->dev, "load_firmware [%s] request failed\n", freertos_img);

--- a/drivers/linux/la9310_limesdr/la9310_ioctl.c
+++ b/drivers/linux/la9310_limesdr/la9310_ioctl.c
@@ -2,6 +2,7 @@
 #include <linux/types.h>
 #include <linux/fs.h>
 #include "la9310_ioctl.h"
+#include "la9310_vspa.h"
 
 #include "la9310_character_device.h"
 #include "la9310_limesdr_device.h"
@@ -36,8 +37,10 @@ void la9310_flush_cache(struct la9310_dev* la9310_dev, struct LA9310_IOCTL_flush
 long la9310_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
 {
     long ret = 0;
+    char fw_name[128];
 
     struct la9310_dev* la9310_dev = file->private_data;
+    struct vspa_device* vspadev = (struct vspa_device*) la9310_dev->vspa_priv;
     struct LA9310_IOCTL_flush_cache cache_entry;
 
     WARN_ON(la9310_dev == NULL);
@@ -76,6 +79,22 @@ long la9310_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
         cache_entry.dir = DMA_BIDIRECTIONAL;
         la9310_flush_cache(la9310_dev, &cache_entry, la9310_dev->iqflood_region.phys_addr);
         ret = 0;
+        break;
+    case LA9310_IOCTL_LOAD_M4_FW:
+        ret = copy_from_user(fw_name, (char *) arg, sizeof(fw_name));
+	if (ret < 0) {
+            dev_err(la9310_dev->dev, "%s copy_from_user, err %d\n", __func__, ret);
+            return ret;
+        }
+        ret = la9310_load_m4_firmware(la9310_dev, fw_name);
+        break;
+    case LA9310_IOCTL_LOAD_VSPA_FW:
+        ret = copy_from_user(fw_name, (char *) arg, sizeof(fw_name));
+	if (ret < 0) {
+            dev_err(la9310_dev->dev, "%s copy_from_user, err %d\n", __func__, ret);
+            return ret;
+        }
+        ret = vspa_load_dsp(la9310_dev, vspadev, fw_name);
         break;
     case LA9310_IOCTL_CSR_OP: {
         struct LA9310_IOCTL_CSR_op op;

--- a/drivers/linux/la9310_limesdr/la9310_ioctl.c
+++ b/drivers/linux/la9310_limesdr/la9310_ioctl.c
@@ -37,11 +37,11 @@ void la9310_flush_cache(struct la9310_dev* la9310_dev, struct LA9310_IOCTL_flush
 long la9310_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
 {
     long ret = 0;
-    char fw_name[128];
 
     struct la9310_dev* la9310_dev = file->private_data;
     struct vspa_device* vspadev = (struct vspa_device*) la9310_dev->vspa_priv;
     struct LA9310_IOCTL_flush_cache cache_entry;
+    struct LA9310_IOCTL_firmware fw;
 
     WARN_ON(la9310_dev == NULL);
 
@@ -81,20 +81,20 @@ long la9310_ioctl(struct file* file, unsigned int cmd, unsigned long arg)
         ret = 0;
         break;
     case LA9310_IOCTL_LOAD_M4_FW:
-        ret = copy_from_user(fw_name, (char *) arg, sizeof(fw_name));
+        ret = copy_from_user(&fw, (struct LA9310_IOCTL_firmware *) arg, sizeof(fw));
 	if (ret < 0) {
-            dev_err(la9310_dev->dev, "%s copy_from_user, err %d\n", __func__, ret);
+            dev_err(la9310_dev->dev, "%s copy_from_user, err %ld\n", __func__, ret);
             return ret;
         }
-        ret = la9310_load_m4_firmware(la9310_dev, fw_name);
+        ret = la9310_load_m4_firmware(la9310_dev, fw.firmware_data, fw.size);
         break;
     case LA9310_IOCTL_LOAD_VSPA_FW:
-        ret = copy_from_user(fw_name, (char *) arg, sizeof(fw_name));
+        ret = copy_from_user(&fw, (struct LA9310_IOCTL_firmware *) arg, sizeof(fw));
 	if (ret < 0) {
-            dev_err(la9310_dev->dev, "%s copy_from_user, err %d\n", __func__, ret);
+            dev_err(la9310_dev->dev, "%s copy_from_user, err %ld\n", __func__, ret);
             return ret;
         }
-        ret = vspa_load_dsp(la9310_dev, vspadev, fw_name);
+        ret = vspa_load_dsp(la9310_dev, vspadev, fw.firmware_data, fw.size);
         break;
     case LA9310_IOCTL_CSR_OP: {
         struct LA9310_IOCTL_CSR_op op;

--- a/drivers/linux/la9310_limesdr/la9310_ioctl.h
+++ b/drivers/linux/la9310_limesdr/la9310_ioctl.h
@@ -49,8 +49,8 @@ struct LA9310_IOCTL_CSR_op {
 #define LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM _IOR(LA9310_IOCTL, 26, struct LA9310_IOCTL_flush_cache)
 #define LA9310_IOCTL_FLUSH_CACHE_IQFLOOD _IOR(LA9310_IOCTL, 27, struct LA9310_IOCTL_flush_cache)
 #define LA9310_IOCTL_CSR_OP _IOR(LA9310_IOCTL, 28, struct LA9310_IOCTL_CSR_op)
-#define LA9310_IOCTL_LOAD_M4_FW _IOR(LA9310_IOCTL, 29, char *)
-#define LA9310_IOCTL_LOAD_VSPA_FW _IOR(LA9310_IOCTL, 30, char *)
+#define LA9310_IOCTL_LOAD_M4_FW _IOR(LA9310_IOCTL, 29, struct LA9310_IOCTL_firmware)
+#define LA9310_IOCTL_LOAD_VSPA_FW _IOR(LA9310_IOCTL, 30, struct LA9310_IOCTL_firmware)
 
 long la9310_ioctl(struct file* file, unsigned int cmd, unsigned long arg);
 

--- a/drivers/linux/la9310_limesdr/la9310_ioctl.h
+++ b/drivers/linux/la9310_limesdr/la9310_ioctl.h
@@ -48,7 +48,9 @@ struct LA9310_IOCTL_CSR_op {
 #define LA9310_IOCTL_GET_MEMORY_LAYOUT _IOR(LA9310_IOCTL, 25, struct LA9310_IOCTL_memory_layout)
 #define LA9310_IOCTL_FLUSH_CACHE_VSPA_DMEM _IOR(LA9310_IOCTL, 26, struct LA9310_IOCTL_flush_cache)
 #define LA9310_IOCTL_FLUSH_CACHE_IQFLOOD _IOR(LA9310_IOCTL, 27, struct LA9310_IOCTL_flush_cache)
-#define LA9310_IOCTL_CSR_OP _IOR(LA9310_IOCTL, 26, struct LA9310_IOCTL_CSR_op)
+#define LA9310_IOCTL_CSR_OP _IOR(LA9310_IOCTL, 28, struct LA9310_IOCTL_CSR_op)
+#define LA9310_IOCTL_LOAD_M4_FW _IOR(LA9310_IOCTL, 29, char *)
+#define LA9310_IOCTL_LOAD_VSPA_FW _IOR(LA9310_IOCTL, 30, char *)
 
 long la9310_ioctl(struct file* file, unsigned int cmd, unsigned long arg);
 

--- a/drivers/linux/la9310_limesdr/la9310_pci.c
+++ b/drivers/linux/la9310_limesdr/la9310_pci.c
@@ -316,7 +316,7 @@ static struct la9310_dev* la9310_pci_priv_init(struct pci_dev* pdev)
 
     la9310_dev->modem_rf_data_size = 0;
 
-    sprintf(la9310_dev->firmware_name, "la9310.bin");
+    //sprintf(la9310_dev->firmware_name, "la9310.bin");
     // char vspa_fw_name[];
     // sprintf(la9310_dev_name, "devname");
 

--- a/drivers/linux/la9310_limesdr/la9310_vspa.c
+++ b/drivers/linux/la9310_limesdr/la9310_vspa.c
@@ -890,6 +890,15 @@ int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, co
 {
 	int err;
 
+	if (!la9310_dev->arm_m4_fw_loaded) {
+		dev_err(la9310_dev->dev, "Firmware for M4 is not loaded yet but required for VSPA DSP loading!\n");
+		return -EPERM;
+	}
+
+	if (la9310_dev->vspa_fw_loaded) {
+		dev_err(la9310_dev->dev, "Firmware for VSPA DSP is already loaded!\n");
+		return -EBUSY;
+	}
 	dev_info(la9310_dev->dev, "INFO:%s : VSPA Loading firmware initiated-\n", __func__);
 
 	vspadev->state = VSPA_STATE_LOADING;
@@ -925,6 +934,7 @@ int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, co
 
 	dev_dbg(la9310_dev->dev, "DBG: Fw image name saved: %s", vspadev->eld_filename);
 
+	la9310_dev->vspa_fw_loaded = 1;
 	return 0;
 }
 

--- a/drivers/linux/la9310_limesdr/la9310_vspa.c
+++ b/drivers/linux/la9310_limesdr/la9310_vspa.c
@@ -886,6 +886,51 @@ OUT:
     return -EFAULT;
 }
 
+int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, const char *dsp_fw_name)
+{
+	int err;
+
+	dev_info(la9310_dev->dev, "INFO:%s : VSPA Loading firmware initiated-\n", __func__);
+
+	vspadev->state = VSPA_STATE_LOADING;
+
+	err = vspa_mem_initialization(vspadev);
+	if (err < 0) {
+		dev_err(vspadev->dev, "Memory Zeroise failed\n");
+		return err;
+	}
+	dev_info(la9310_dev->dev, "mem init done\n");
+
+	// snprintf(vspadev->eld_filename, VSPA_MAX_ELD_FILENAME, "%s", vspa_fw_name);
+	snprintf(vspadev->eld_filename, VSPA_MAX_ELD_FILENAME, "%s", dsp_fw_name);
+
+	/* Call the LA9310 base APIs to request_firmware */
+	if (vspa_get_fw_image(la9310_dev)) {
+		dev_err(la9310_dev->dev, "ERR %s : Loading VSPA FW failed\n", __func__);
+		err = -EBADRQC;
+		return err;
+	}
+
+	dev_info(la9310_dev->dev, "INFO:%s :VSPA FW image %s loading finished\n", __func__, vspadev->eld_filename);
+
+	/* Initiate the VSPA_GO to start VSPA booting */
+	if (startup(la9310_dev)) {
+		dev_err(la9310_dev->dev, "ERR %s: VSPA failed to start VSPA\n", __func__);
+		err = -EBADRQC;
+		return err;
+	}
+
+	err = la9310_vspa_stats_init(la9310_dev);
+	if (err < 0) {
+		dev_err(la9310_dev->dev, "ERR: VSPA stats error\n");
+		return err;
+	}
+
+	dev_dbg(la9310_dev->dev, "DBG: Fw image name saved: %s", vspadev->eld_filename);
+
+	return 0;
+}
+
 /************************* Probe / Remove ***********************************/
 
 int vspa_probe(struct la9310_dev* la9310_dev, int vspa_irq_count, struct virq_evt_map* vspa_virq_map)
@@ -1005,47 +1050,9 @@ int vspa_probe(struct la9310_dev* la9310_dev, int vspa_irq_count, struct virq_ev
         hw->arithmetic_units,
         hw->dmem_bytes);
 
-    dev_info(la9310_dev->dev, "INFO:%s : VSPA Loading firmware initiated-\n", __func__);
-
-    vspadev->state = VSPA_STATE_LOADING;
-
-    err = vspa_mem_initialization(vspadev);
-    if (err < 0)
-    {
-        dev_err(vspadev->dev, "Memory Zeroise failed\n");
-        goto err_out;
-    }
-    dev_info(la9310_dev->dev, "mem init done\n");
-
-    // snprintf(vspadev->eld_filename, VSPA_MAX_ELD_FILENAME, "%s", vspa_fw_name);
-    snprintf(vspadev->eld_filename, VSPA_MAX_ELD_FILENAME, "%s", "apm-iqplayer.eld");
-
-    /* Call the LA9310 base APIs to request_firmware */
-    if (vspa_get_fw_image(la9310_dev))
-    {
-        dev_err(la9310_dev->dev, "ERR %s : Loading VSPA FW failed\n", __func__);
-        err = -EBADRQC;
-        goto err_out;
-    }
-
-    dev_info(la9310_dev->dev, "INFO:%s :VSPA FW image %s loading finished\n", __func__, vspadev->eld_filename);
-
-    /* Initiate the VSPA_GO to start VSPA booting */
-    if (startup(la9310_dev))
-    {
-        dev_err(la9310_dev->dev, "ERR %s: VSPA failed to start VSPA\n", __func__);
-        err = -EBADRQC;
-        goto err_out;
-    }
-
-    err = la9310_vspa_stats_init(la9310_dev);
-    if (err < 0)
-    {
-        dev_err(la9310_dev->dev, "ERR: VSPA stats error\n");
-        goto err_out;
-    }
-
-    dev_dbg(la9310_dev->dev, "DBG: Fw image name saved: %s", vspadev->eld_filename);
+//    err = vspa_load_dsp(la9310_dev, vspadev, "apm-iqplayer.eld");
+//    if (err)
+//	    goto err_out;
 
     /*Clearing the VCPU_TO_HOST MBOXs */
     vspa_reg_write(vspadev->regs + HOST_FLAGS0_REG_OFFSET, 0xFFFFFFFFUL);

--- a/drivers/linux/la9310_limesdr/la9310_vspa.c
+++ b/drivers/linux/la9310_limesdr/la9310_vspa.c
@@ -829,7 +829,7 @@ int overlay_initiate(struct device* dev, struct overlay_section overlay_sec)
     return 0;
 }
 
-static int vspa_get_fw_image(struct la9310_dev* la9310_dev)
+static int vspa_get_fw_image(struct la9310_dev* la9310_dev, const char __user *fw_data, size_t fw_length)
 {
     int ret = 0;
     int buf_size, vspa_fw_size;
@@ -853,7 +853,7 @@ static int vspa_get_fw_image(struct la9310_dev* la9310_dev)
 
     dma_sync_single_for_cpu(
         la9310_dev->dev, la9310_dev->dma_info.host_buf.phys_addr, la9310_dev->dma_info.host_buf.size, DMA_BIDIRECTIONAL);
-    ret = la9310_udev_load_firmware(la9310_dev, vspa_fw_region->vaddr, buf_size, vspadev->eld_filename);
+    ret = la9310_load_firmware(la9310_dev, vspa_fw_region->vaddr, buf_size, fw_data, fw_length);
     if (ret < 0)
     {
         dev_err(la9310_dev->dev, "%s: load_firmware request failed\n", __func__);
@@ -886,7 +886,7 @@ OUT:
     return -EFAULT;
 }
 
-int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, const char *dsp_fw_name)
+int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, const char __user *fw_data, size_t fw_length)
 {
 	int err;
 
@@ -901,11 +901,8 @@ int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, co
 	}
 	dev_info(la9310_dev->dev, "mem init done\n");
 
-	// snprintf(vspadev->eld_filename, VSPA_MAX_ELD_FILENAME, "%s", vspa_fw_name);
-	snprintf(vspadev->eld_filename, VSPA_MAX_ELD_FILENAME, "%s", dsp_fw_name);
-
 	/* Call the LA9310 base APIs to request_firmware */
-	if (vspa_get_fw_image(la9310_dev)) {
+	if (vspa_get_fw_image(la9310_dev, fw_data, fw_length)) {
 		dev_err(la9310_dev->dev, "ERR %s : Loading VSPA FW failed\n", __func__);
 		err = -EBADRQC;
 		return err;

--- a/drivers/linux/la9310_limesdr/la9310_vspa.h
+++ b/drivers/linux/la9310_limesdr/la9310_vspa.h
@@ -703,6 +703,6 @@ static inline unsigned int vspa_reg_read(void __iomem* addr)
 
 int full_state(struct vspa_device* vspadev);
 int overlay_initiate(struct device* dev, struct overlay_section overlay_sec);
-int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, const char *dsp_fw_name);
+int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, const char __user *fw_data, size_t fw_length);
 
 #endif /* _VSPA_H */

--- a/drivers/linux/la9310_limesdr/la9310_vspa.h
+++ b/drivers/linux/la9310_limesdr/la9310_vspa.h
@@ -10,6 +10,7 @@
 #include <linux/list.h>
 #include <linux/completion.h>
 #include "la9310_pci.h"
+#include "la9310_base.h"
 
 #ifndef __VSPA_H_
     #define __VSPA_H_
@@ -702,4 +703,6 @@ static inline unsigned int vspa_reg_read(void __iomem* addr)
 
 int full_state(struct vspa_device* vspadev);
 int overlay_initiate(struct device* dev, struct overlay_section overlay_sec);
+int vspa_load_dsp(struct la9310_dev *la9310_dev, struct vspa_device* vspadev, const char *dsp_fw_name);
+
 #endif /* _VSPA_H */

--- a/src/boards/LimeSDR_Micro/LimeSDR_Micro.cpp
+++ b/src/boards/LimeSDR_Micro/LimeSDR_Micro.cpp
@@ -499,44 +499,23 @@ OpStatus LimeSDR_Micro::UploadMemory(
     eMemoryDevice device, uint8_t moduleIndex, const char* data, size_t length, UploadMemoryCallback callback)
 {
     int status;
-    std::string filename, devfile;
-    std::ofstream file;
 
     switch (device)
     {
     case eMemoryDevice::ARM_M4:
-        filename = "/lib/firmware/arm_m4_fw.bin";
-
-        /* Write firmware to temporary binary file */
-        file.open(filename, std::ios::binary);
-        file.write(data, length);
-        file.close();
-
-	filename = "arm_m4_fw.bin";
-
-        status = mStreamingPort->LoadArmM4Fw(filename.c_str());
-	    break;
+        status = mStreamingPort->LoadArmM4Fw(data, length);
+        break;
     case eMemoryDevice::VSPA:
-        filename = "/lib/firmware/vspa_fw.bin";
-
-        /* Write firmware to temporary binary file */
-        file.open(filename, std::ios::binary);
-        file.write(data, length);
-        file.close();
-
-	filename = "vspa_fw.bin";
-
-        status = mStreamingPort->LoadVspaFw(filename.c_str());
-	    break;
+        status = mStreamingPort->LoadVspaFw(data, length);
+        break;
     default:
         return OpStatus::NotImplemented;
     }
 
-
     if (status)
         return OpStatus::IOFailure;
     else
-    	return OpStatus::Success;
+        return OpStatus::Success;
 }
 
 OpStatus LimeSDR_Micro::MemoryWrite(std::shared_ptr<DataStorage> storage, Region region, const void* data)

--- a/src/boards/LimeSDR_Micro/LimeSDR_Micro.cpp
+++ b/src/boards/LimeSDR_Micro/LimeSDR_Micro.cpp
@@ -1,9 +1,10 @@
 #include "LimeSDR_Micro.h"
 
 #include <cmath>
-#include <fcntl.h>
-#include <unistd.h>
 #include <sstream>
+#include <string>
+#include <iostream>
+#include <fstream>
 
 #include "limesuiteng/Logger.h"
 #include "limesuiteng/LMS7002M.h"
@@ -20,11 +21,13 @@
 #include "protocols/LMS64C/SPI.h"
 #include "streaming/TRXLooper.h"
 
+#ifdef __unix__
 // Linux headers
 #include <fcntl.h> // Contains file controls like O_RDWR
 #include <errno.h> // Error integer and strerror() function
 #include <termios.h> // Contains POSIX terminal control definitions
 #include <unistd.h> // write(), read(), close()
+#endif
 
 #include "chips/LMS7002M/validation.h"
 #include "chips/LMS7002M/LMS7002MCSR_Data.h"
@@ -37,6 +40,7 @@
 #include "DeviceTreeNode.h"
 
 #include "LA9310_TRX.h"
+#include "comms/PCIe/LA9310_PCIe.h"
 
 using namespace std::literals::string_literals;
 using namespace lime::LMS7002MCSR_Data;
@@ -494,13 +498,45 @@ void LimeSDR_Micro::LMSSetPath(TRXDir dir, uint8_t chan, uint8_t pathId)
 OpStatus LimeSDR_Micro::UploadMemory(
     eMemoryDevice device, uint8_t moduleIndex, const char* data, size_t length, UploadMemoryCallback callback)
 {
+    int status;
+    std::string filename, devfile;
+    std::ofstream file;
+
     switch (device)
     {
     case eMemoryDevice::ARM_M4:
+        filename = "/lib/firmware/arm_m4_fw.bin";
+
+        /* Write firmware to temporary binary file */
+        file.open(filename, std::ios::binary);
+        file.write(data, length);
+        file.close();
+
+	filename = "arm_m4_fw.bin";
+
+        status = mStreamingPort->LoadArmM4Fw(filename.c_str());
+	    break;
     case eMemoryDevice::VSPA:
+        filename = "/lib/firmware/vspa_fw.bin";
+
+        /* Write firmware to temporary binary file */
+        file.open(filename, std::ios::binary);
+        file.write(data, length);
+        file.close();
+
+	filename = "vspa_fw.bin";
+
+        status = mStreamingPort->LoadVspaFw(filename.c_str());
+	    break;
     default:
         return OpStatus::NotImplemented;
     }
+
+
+    if (status)
+        return OpStatus::IOFailure;
+    else
+    	return OpStatus::Success;
 }
 
 OpStatus LimeSDR_Micro::MemoryWrite(std::shared_ptr<DataStorage> storage, Region region, const void* data)

--- a/src/comms/PCIe/LA9310_PCIe.cpp
+++ b/src/comms/PCIe/LA9310_PCIe.cpp
@@ -283,3 +283,13 @@ uint32_t PCIe_CSR_Access::ioread32(size_t offset)
 {
     return port->ioread32(window_id, base_offset + offset);
 }
+
+int LA9310_PCIe::LoadArmM4Fw(const char *fw_name)
+{
+    return ioctl(mFileDescriptor, LA9310_IOCTL_LOAD_M4_FW, fw_name);
+}
+
+int LA9310_PCIe::LoadVspaFw(const char *fw_name)
+{
+    return ioctl(mFileDescriptor, LA9310_IOCTL_LOAD_VSPA_FW, fw_name);
+}

--- a/src/comms/PCIe/LA9310_PCIe.cpp
+++ b/src/comms/PCIe/LA9310_PCIe.cpp
@@ -284,12 +284,21 @@ uint32_t PCIe_CSR_Access::ioread32(size_t offset)
     return port->ioread32(window_id, base_offset + offset);
 }
 
-int LA9310_PCIe::LoadArmM4Fw(const char *fw_name)
+int LA9310_PCIe::LoadArmM4Fw(const char *data, size_t length)
 {
-    return ioctl(mFileDescriptor, LA9310_IOCTL_LOAD_M4_FW, fw_name);
+    struct LA9310_IOCTL_firmware fw = {
+        data,
+        length
+    };
+    return ioctl(mFileDescriptor, LA9310_IOCTL_LOAD_M4_FW, &fw);
 }
 
-int LA9310_PCIe::LoadVspaFw(const char *fw_name)
+int LA9310_PCIe::LoadVspaFw(const char *data, size_t length)
 {
-    return ioctl(mFileDescriptor, LA9310_IOCTL_LOAD_VSPA_FW, fw_name);
+    struct LA9310_IOCTL_firmware fw = {
+        data,
+        length
+    };
+
+    return ioctl(mFileDescriptor, LA9310_IOCTL_LOAD_VSPA_FW, &fw);
 }

--- a/src/comms/PCIe/LA9310_PCIe.h
+++ b/src/comms/PCIe/LA9310_PCIe.h
@@ -94,14 +94,16 @@ class LIME_API LA9310_PCIe : public LimePCIe
     void sync_iq_flood_after_write(uint8_t* addr, uint32_t data_size);
 
     /// @brief Downloads the Firmware for the ARM M4 core on the LA9310 device
-    /// @param File name of the firmware file
+    /// @param Firmware data
+    /// @param size of firmware data 
     /// @return 0 on success, error code else
-    int LoadArmM4Fw(const char *fw_name);
+    int LoadArmM4Fw(const char *data, size_t length);
 
     /// @brief Downloads the Firmware for the VSPA core on the LA9310 device
-    /// @param File name of the firmware file
+    /// @param Firmware data
+    /// @param size of firmware data 
     /// @return 0 on success, error code else
-    int LoadVspaFw(const char *fw_name);
+    int LoadVspaFw(const char *data, size_t length);
 
     mmaped_region GetBar(uint8_t i);
     std::shared_ptr<PCIe_CSR_Access> GetCSRAccess(uint32_t window_id, size_t base_offset = 0)

--- a/src/comms/PCIe/LA9310_PCIe.h
+++ b/src/comms/PCIe/LA9310_PCIe.h
@@ -93,6 +93,16 @@ class LIME_API LA9310_PCIe : public LimePCIe
     /// @param data size to sync
     void sync_iq_flood_after_write(uint8_t* addr, uint32_t data_size);
 
+    /// @brief Downloads the Firmware for the ARM M4 core on the LA9310 device
+    /// @param File name of the firmware file
+    /// @return 0 on success, error code else
+    int LoadArmM4Fw(const char *fw_name);
+
+    /// @brief Downloads the Firmware for the VSPA core on the LA9310 device
+    /// @param File name of the firmware file
+    /// @return 0 on success, error code else
+    int LoadVspaFw(const char *fw_name);
+
     mmaped_region GetBar(uint8_t i);
     std::shared_ptr<PCIe_CSR_Access> GetCSRAccess(uint32_t window_id, size_t base_offset = 0)
     {


### PR DESCRIPTION
This PR splits the probing of the LA9310 device and the firmware loading into ARM M4 and DSP cores and adds ioctls to load the firmware.