### PR TITLE
GUI: Fix static initialization order fiasco in SOC_GUIFactory

### DIFF
--- a/GUI/SOC_GUIFactory.cpp
+++ b/GUI/SOC_GUIFactory.cpp
@@ -3,28 +3,32 @@
 #include <utility>
 #include <cstdio>
 
+// Construct On First Use idiom - guarantees the map is initialized before any Register calls
+std::unordered_map<std::string, panelConstructorFunc>& SOC_GUIFactory::RegisteredNames()
+{
+    static std::unordered_map<std::string, panelConstructorFunc> instance;
+    return instance;
+}
+
 bool SOC_GUIFactory::Register(std::string_view name, panelConstructorFunc createMethod)
 {
-    const auto registeredPair = SOC_GUIFactory::RegisteredNames.find(std::string(name));
-    if (registeredPair != SOC_GUIFactory::RegisteredNames.end())
+    const auto registeredPair = SOC_GUIFactory::RegisteredNames().find(std::string(name));
+    if (registeredPair != SOC_GUIFactory::RegisteredNames().end())
     {
         std::cerr << "SOC_GUIFactory: class(" << name << ") already registered" << std::endl;
         return false;
     }
 
     // std::cout << "SOC GUI registered(" << name << ")\n";
-    SOC_GUIFactory::RegisteredNames.insert(std::make_pair(std::string(name), createMethod));
+    SOC_GUIFactory::RegisteredNames().insert(std::make_pair(std::string(name), createMethod));
     return true;
 }
 
 ISOCPanel* SOC_GUIFactory::make(std::string_view name, wxWindow* parent, wxWindowID id)
 {
-    auto registeredPair = SOC_GUIFactory::RegisteredNames.find(std::string(name));
-    if (registeredPair == SOC_GUIFactory::RegisteredNames.end())
+    auto registeredPair = SOC_GUIFactory::RegisteredNames().find(std::string(name));
+    if (registeredPair == SOC_GUIFactory::RegisteredNames().end())
         return nullptr;
 
     return registeredPair->second(parent, id);
 }
-
-// initialise the registered names map
-std::unordered_map<std::string, panelConstructorFunc> SOC_GUIFactory::RegisteredNames = {};

--- a/GUI/SOC_GUIFactory.h
+++ b/GUI/SOC_GUIFactory.h
@@ -15,7 +15,7 @@ class SOC_GUIFactory
     static ISOCPanel* make(const std::string_view name, wxWindow* parent, wxWindowID id);
 
   protected:
-    static std::unordered_map<std::string, panelConstructorFunc> RegisteredNames;
+    static std::unordered_map<std::string, panelConstructorFunc>& RegisteredNames();
 };
 
 template<class FactoryT, panelConstructorFunc CreateMethod> bool RegisterToFactory(std::string_view name)


### PR DESCRIPTION
Fixes `Integer divide by zero` crash while launching limeGUI.

```
$ valgrind limeGUI 
==687820== Memcheck, a memory error detector
==687820== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==687820== Using Valgrind-3.25.1 and LibVEX; rerun with -h for copyright info
==687820== Command: limeGUI
==687820== 
==687820== 
==687820== Process terminating with default action of signal 8 (SIGFPE): dumping core
==687820==  Integer divide by zero at address 0x10033C5492
==687820==    at 0x40958AD: UnknownInlinedFun (hashtable_policy.h:584)
==687820==    by 0x40958AD: UnknownInlinedFun (hashtable_policy.h:1093)
==687820==    by 0x40958AD: UnknownInlinedFun (hashtable.h:811)
==687820==    by 0x40958AD: std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ISOCPanel* (*)(wxWindow*, int)>, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ISOCPanel* (*)(wxWindow*, int)> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::_M_locate(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const [clone .constprop.0] (hashtable.h:2280)
==687820==    by 0x4095A60: UnknownInlinedFun (hashtable.h:1918)
==687820==    by 0x4095A60: UnknownInlinedFun (unordered_map.h:947)
==687820==    by 0x4095A60: SOC_GUIFactory::Register(std::basic_string_view<char, std::char_traits<char> >, ISOCPanel* (*)(wxWindow*, int)) (SOC_GUIFactory.cpp:8)
==687820==    by 0x409640E: _sub_I_65535_0.0 (in /usr/bin/limeGUI)
==687820==    by 0x5C74763: call_init (libc-start.c:145)
==687820==    by 0x5C74763: __libc_start_main@@GLIBC_2.34 (libc-start.c:347)
==687820==    by 0x40973F4: (below main) (in /usr/bin/limeGUI)
==687820== 
==687820== HEAP SUMMARY:
==687820==     in use at exit: 380,083 bytes in 2,690 blocks
==687820==   total heap usage: 4,103 allocs, 1,413 frees, 461,375 bytes allocated
==687820== 
==687820== LEAK SUMMARY:
==687820==    definitely lost: 0 bytes in 0 blocks
==687820==    indirectly lost: 0 bytes in 0 blocks
==687820==      possibly lost: 5,856 bytes in 5 blocks
==687820==    still reachable: 372,379 bytes in 2,664 blocks
==687820==         suppressed: 0 bytes in 0 blocks
==687820== Rerun with --leak-check=full to see details of leaked memory
==687820== 
==687820== For lists of detected and suppressed errors, rerun with: -s
==687820== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Floating point exception   (core dumped) valgrind limeGUI
```