### PR TITLE
gr-limesuiteng: expose linkFormat, always output fc32

### DIFF
--- a/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_sink.block.yml
+++ b/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_sink.block.yml
@@ -6,6 +6,17 @@ flags: throttle
 file_format: 1
 
 parameters:
+- id: data_format
+  label: Data Format
+  dtype: enum
+  options: [fc32, sc16]
+  option_labels: ["Complex Float32", "Complex Int16"]
+  option_attributes:
+    limeFormat: ["complex32f_t", "complex16_t"]
+  default: fc32
+  hide: all
+  category: General
+
 - id: link_format
   label: Link Format
   dtype: enum
@@ -128,7 +139,7 @@ asserts:
 templates:
   imports: from gnuradio import limesuiteng
   make: |-
-    limesuiteng.sdrdevice_sink(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ link_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
+    limesuiteng.sdrdevice_sink(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ data_format.limeFormat }", "${ link_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
     self.${id}.set_lo_frequency(${rf_freq})
     self.${id}.set_lpf_bandwidth(${lpf})
     self.${id}.set_gfir_bandwidth(${gfir_bandwidth})

--- a/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_sink.block.yml
+++ b/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_sink.block.yml
@@ -12,19 +12,20 @@ parameters:
   options: [fc32, sc16]
   option_labels: ["Complex Float32", "Complex Int16"]
   option_attributes:
+    type: [fc32, sc16]
     limeFormat: ["complex32f_t", "complex16_t"]
   default: fc32
-  hide: all
+  hide: part
   category: General
 
 - id: link_format
   label: Link Format
   dtype: enum
   options: [i16, i12]
-  option_labels: ["I16 - 4 bytes/sample (default)", "I12 - 3 bytes/sample (XTRX bandwidth saving)"]
+  option_labels: ["I16 - 4 bytes/sample", "I12 - 3 bytes/sample"]
   option_attributes:
     limeFormat: ["complex16_t", "complex12_t"]
-  default: i16
+  default: i12
   hide: ${'part' if link_format == 'i16' else 'none'}
   category: General
 
@@ -124,7 +125,7 @@ parameters:
 inputs:
 - label: in
   domain: stream
-  dtype: fc32
+  dtype: ${ data_format.type }
   multiplicity: ${ len(channel_indexes) }
 # must be connected
   optional: false

--- a/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_sink.block.yml
+++ b/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_sink.block.yml
@@ -6,15 +6,15 @@ flags: throttle
 file_format: 1
 
 parameters:
-- id: data_format
-  label: Type
+- id: link_format
+  label: Link Format
   dtype: enum
-  options: [fc32, sc16]
-  option_labels: [Complex Float32, Complex Int16]
+  options: [i16, i12]
+  option_labels: ["I16 - 4 bytes/sample (default)", "I12 - 3 bytes/sample (XTRX bandwidth saving)"]
   option_attributes:
-    type: [fc32, sc16]
-    limeFormat: ["complex32f_t", "complex16_t"]
-  hide: part
+    limeFormat: ["complex16_t", "complex12_t"]
+  default: i16
+  hide: ${'part' if link_format == 'i16' else 'none'}
   category: General
 
 - id: custom_config_file
@@ -113,7 +113,7 @@ parameters:
 inputs:
 - label: in
   domain: stream
-  dtype: ${ data_format.type }
+  dtype: fc32
   multiplicity: ${ len(channel_indexes) }
 # must be connected
   optional: false
@@ -128,7 +128,7 @@ asserts:
 templates:
   imports: from gnuradio import limesuiteng
   make: |-
-    limesuiteng.sdrdevice_sink(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ data_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
+    limesuiteng.sdrdevice_sink(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ link_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
     self.${id}.set_lo_frequency(${rf_freq})
     self.${id}.set_lpf_bandwidth(${lpf})
     self.${id}.set_gfir_bandwidth(${gfir_bandwidth})

--- a/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_source.block.yml
+++ b/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_source.block.yml
@@ -6,6 +6,17 @@ flags: throttle
 file_format: 1
 
 parameters:
+- id: data_format
+  label: Data Format
+  dtype: enum
+  options: [fc32, sc16]
+  option_labels: ["Complex Float32", "Complex Int16"]
+  option_attributes:
+    limeFormat: ["complex32f_t", "complex16_t"]
+  default: fc32
+  hide: all
+  category: General
+
 - id: link_format
   label: Link Format
   dtype: enum
@@ -166,7 +177,7 @@ asserts:
 templates:
   imports: from gnuradio import limesuiteng
   make: |-
-    limesuiteng.sdrdevice_source(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ link_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
+    limesuiteng.sdrdevice_source(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ data_format.limeFormat }", "${ link_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
     self.${id}.set_lo_frequency(${rf_freq})
     self.${id}.set_gfir_bandwidth(${gfir_bandwidth})
     self.${id}.set_antenna(${antenna})

--- a/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_source.block.yml
+++ b/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_source.block.yml
@@ -6,15 +6,15 @@ flags: throttle
 file_format: 1
 
 parameters:
-- id: data_format
-  label: Type
+- id: link_format
+  label: Link Format
   dtype: enum
-  options: [fc32, sc16]
-  option_labels: [Complex Float32, Complex Int16]
+  options: [i16, i12]
+  option_labels: ["I16 - 4 bytes/sample (default)", "I12 - 3 bytes/sample (XTRX bandwidth saving)"]
   option_attributes:
-    type: [fc32, sc16]
-    limeFormat: ["complex32f_t", "complex16_t"]
-  hide: part
+    limeFormat: ["complex16_t", "complex12_t"]
+  default: i16
+  hide: ${'part' if link_format == 'i16' else 'none'}
   category: General
 
 - id: custom_config_file
@@ -151,7 +151,7 @@ parameters:
 outputs:
 - label: out
   domain: stream
-  dtype: ${ data_format.type }
+  dtype: fc32
   multiplicity: ${ len(channel_indexes) }
 # must be connected
   optional: false
@@ -166,7 +166,7 @@ asserts:
 templates:
   imports: from gnuradio import limesuiteng
   make: |-
-    limesuiteng.sdrdevice_source(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ data_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
+    limesuiteng.sdrdevice_source(${alias}, ${deviceHandleHint}, ${chip_index}, ${ channel_indexes }, "${ link_format.limeFormat }", ${sample_rate}, ${rf_oversampling.value})
     self.${id}.set_lo_frequency(${rf_freq})
     self.${id}.set_gfir_bandwidth(${gfir_bandwidth})
     self.${id}.set_antenna(${antenna})

--- a/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_source.block.yml
+++ b/plugins/gr-limesuiteng/grc/limesuiteng_sdrdevice_source.block.yml
@@ -12,19 +12,20 @@ parameters:
   options: [fc32, sc16]
   option_labels: ["Complex Float32", "Complex Int16"]
   option_attributes:
+    type: [fc32, sc16]
     limeFormat: ["complex32f_t", "complex16_t"]
   default: fc32
-  hide: all
+  hide: part
   category: General
 
 - id: link_format
   label: Link Format
   dtype: enum
   options: [i16, i12]
-  option_labels: ["I16 - 4 bytes/sample (default)", "I12 - 3 bytes/sample (XTRX bandwidth saving)"]
+  option_labels: ["I16 - 4 bytes/sample", "I12 - 3 bytes/sample"]
   option_attributes:
     limeFormat: ["complex16_t", "complex12_t"]
-  default: i16
+  default: i12
   hide: ${'part' if link_format == 'i16' else 'none'}
   category: General
 
@@ -162,7 +163,7 @@ parameters:
 outputs:
 - label: out
   domain: stream
-  dtype: fc32
+  dtype: ${ data_format.type }
   multiplicity: ${ len(channel_indexes) }
 # must be connected
   optional: false

--- a/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_sink.h
+++ b/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_sink.h
@@ -40,9 +40,10 @@ public:
      * @param   chipIndex If multiple RFSOC are available on the device, specify which one
      * to use
      * @param   channelCount Number of data channels
+     * @param   dataFormat Input sample format accepted from GNURadio (complex32f_t = fc32,
+     * complex16_t = sc16). Defaults to complex32f_t.
      * @param   linkFormat DMA link layer format (complex16_t = I16 4B/sample,
      * complex12_t = I12 3B/sample). Use complex12_t to reduce PCIe bandwidth on XTRX.
-     * Input samples from GNURadio are always expected as fc32 regardless of linkFormat.
      * @param   sampleRate Data interface sampling rate
      * @param   rf_oversampling RF sampling decimation ratio (0-max possible, x1, x2,
      * x4...)
@@ -51,9 +52,10 @@ public:
                      const std::string& deviceHandleHint,
                      uint32_t chipIndex,
                      const std::vector<int>& channelIndexes,
-                     const std::string& linkFormat = "complex16_t",
-                     double sampleRate = 10e6,
-                     int rf_oversampling = 0);
+                     const std::string& dataFormat,
+                     const std::string& linkFormat,
+                     double sampleRate,
+                     int rf_oversampling);
 
     /**
      * Set custom configuration file to be used as base settings

--- a/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_sink.h
+++ b/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_sink.h
@@ -40,7 +40,9 @@ public:
      * @param   chipIndex If multiple RFSOC are available on the device, specify which one
      * to use
      * @param   channelCount Number of data channels
-     * @param   dataFormat Output samples format
+     * @param   linkFormat DMA link layer format (complex16_t = I16 4B/sample,
+     * complex12_t = I12 3B/sample). Use complex12_t to reduce PCIe bandwidth on XTRX.
+     * Input samples from GNURadio are always expected as fc32 regardless of linkFormat.
      * @param   sampleRate Data interface sampling rate
      * @param   rf_oversampling RF sampling decimation ratio (0-max possible, x1, x2,
      * x4...)
@@ -49,9 +51,9 @@ public:
                      const std::string& deviceHandleHint,
                      uint32_t chipIndex,
                      const std::vector<int>& channelIndexes,
-                     const std::string& dataFormat,
-                     double sampleRate,
-                     int rf_oversampling);
+                     const std::string& linkFormat = "complex16_t",
+                     double sampleRate = 10e6,
+                     int rf_oversampling = 0);
 
     /**
      * Set custom configuration file to be used as base settings

--- a/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_sink.h
+++ b/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_sink.h
@@ -40,8 +40,8 @@ public:
      * @param   chipIndex If multiple RFSOC are available on the device, specify which one
      * to use
      * @param   channelCount Number of data channels
-     * @param   dataFormat Input sample format accepted from GNURadio (complex32f_t = fc32,
-     * complex16_t = sc16). Defaults to complex32f_t.
+     * @param   dataFormat Input sample format accepted from GNURadio (complex32f_t =
+     * fc32, complex16_t = sc16). Defaults to complex32f_t.
      * @param   linkFormat DMA link layer format (complex16_t = I16 4B/sample,
      * complex12_t = I12 3B/sample). Use complex12_t to reduce PCIe bandwidth on XTRX.
      * @param   sampleRate Data interface sampling rate

--- a/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_source.h
+++ b/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_source.h
@@ -40,7 +40,9 @@ public:
      * @param   chipIndex If multiple RFSOC are available on the device, specify which one
      * to use
      * @param   channelCount Number of data channels
-     * @param   dataFormat Output samples format
+     * @param   linkFormat DMA link layer format (complex16_t = I16 4B/sample,
+     * complex12_t = I12 3B/sample). Use complex12_t to reduce PCIe bandwidth on XTRX.
+     * Output samples to GNURadio are always fc32 regardless of linkFormat.
      * @param   sampleRate Data interface sampling rate
      * @param   rf_oversampling RF sampling decimation ratio (0-max possible, x1, x2,
      * x4...)
@@ -49,9 +51,9 @@ public:
                      const std::string& deviceHandleHint,
                      uint32_t chipIndex,
                      const std::vector<int>& channelIndexes,
-                     const std::string& dataFormat,
-                     double sampleRate,
-                     int rf_oversampling);
+                     const std::string& linkFormat = "complex16_t",
+                     double sampleRate = 10e6,
+                     int rf_oversampling = 0);
 
     /**
      * Set custom configuration file to be used as base settings

--- a/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_source.h
+++ b/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_source.h
@@ -40,8 +40,8 @@ public:
      * @param   chipIndex If multiple RFSOC are available on the device, specify which one
      * to use
      * @param   channelCount Number of data channels
-     * @param   dataFormat Output sample format delivered to GNURadio (complex32f_t = fc32,
-     * complex16_t = sc16). Defaults to complex32f_t.
+     * @param   dataFormat Output sample format delivered to GNURadio (complex32f_t =
+     * fc32, complex16_t = sc16). Defaults to complex32f_t.
      * @param   linkFormat DMA link layer format (complex16_t = I16 4B/sample,
      * complex12_t = I12 3B/sample). Use complex12_t to reduce PCIe bandwidth on XTRX.
      * @param   sampleRate Data interface sampling rate

--- a/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_source.h
+++ b/plugins/gr-limesuiteng/include/gnuradio/limesuiteng/sdrdevice_source.h
@@ -40,9 +40,10 @@ public:
      * @param   chipIndex If multiple RFSOC are available on the device, specify which one
      * to use
      * @param   channelCount Number of data channels
+     * @param   dataFormat Output sample format delivered to GNURadio (complex32f_t = fc32,
+     * complex16_t = sc16). Defaults to complex32f_t.
      * @param   linkFormat DMA link layer format (complex16_t = I16 4B/sample,
      * complex12_t = I12 3B/sample). Use complex12_t to reduce PCIe bandwidth on XTRX.
-     * Output samples to GNURadio are always fc32 regardless of linkFormat.
      * @param   sampleRate Data interface sampling rate
      * @param   rf_oversampling RF sampling decimation ratio (0-max possible, x1, x2,
      * x4...)
@@ -51,9 +52,10 @@ public:
                      const std::string& deviceHandleHint,
                      uint32_t chipIndex,
                      const std::vector<int>& channelIndexes,
-                     const std::string& linkFormat = "complex16_t",
-                     double sampleRate = 10e6,
-                     int rf_oversampling = 0);
+                     const std::string& dataFormat,
+                     const std::string& linkFormat,
+                     double sampleRate,
+                     int rf_oversampling);
 
     /**
      * Set custom configuration file to be used as base settings

--- a/plugins/gr-limesuiteng/lib/sdrdevice_block_base.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_block_base.cc
@@ -39,6 +39,7 @@ sdrdevice_block_base::sdrdevice_block_base(lime::TRXDir dir,
                                            const std::string& deviceHandleHint,
                                            uint32_t chipIndex,
                                            const std::vector<int>& channelIndexes,
+                                           const std::string& dataFormat,
                                            const std::string& linkFormat,
                                            double sampleRate,
                                            int rf_oversampling,
@@ -76,7 +77,7 @@ sdrdevice_block_base::sdrdevice_block_base(lime::TRXDir dir,
     for (const auto index : channelIndexes)
         devContext->streamCfg.channels.at(direction).push_back(index);
 
-    devContext->streamCfg.format = lime::DataFormat::F32;
+    devContext->streamCfg.format = GetDataFormatEnum(dataFormat);
     devContext->streamCfg.linkFormat = GetDataFormatEnum(linkFormat);
     devContext->streamCfg.hintSampleRate = sampleRate;
 

--- a/plugins/gr-limesuiteng/lib/sdrdevice_block_base.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_block_base.cc
@@ -39,7 +39,7 @@ sdrdevice_block_base::sdrdevice_block_base(lime::TRXDir dir,
                                            const std::string& deviceHandleHint,
                                            uint32_t chipIndex,
                                            const std::vector<int>& channelIndexes,
-                                           const std::string& dataFormat,
+                                           const std::string& linkFormat,
                                            double sampleRate,
                                            int rf_oversampling,
                                            gr::logger_ptr logger,
@@ -76,8 +76,8 @@ sdrdevice_block_base::sdrdevice_block_base(lime::TRXDir dir,
     for (const auto index : channelIndexes)
         devContext->streamCfg.channels.at(direction).push_back(index);
 
-    devContext->streamCfg.format = GetDataFormatEnum(dataFormat);
-    devContext->streamCfg.linkFormat = lime::DataFormat::I16;
+    devContext->streamCfg.format = lime::DataFormat::F32;
+    devContext->streamCfg.linkFormat = GetDataFormatEnum(linkFormat);
     devContext->streamCfg.hintSampleRate = sampleRate;
 
     lime::SDRConfig& config = devContext->deviceConfig;

--- a/plugins/gr-limesuiteng/lib/sdrdevice_block_base.h
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_block_base.h
@@ -27,7 +27,7 @@ public:
                          const std::string& deviceHandleHint,
                          uint32_t chipIndex,
                          const std::vector<int>& channelIndexes,
-                         const std::string& dataFormat,
+                         const std::string& linkFormat,
                          double sampleRate,
                          int rf_oversampling,
                          gr::logger_ptr logger,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_block_base.h
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_block_base.h
@@ -27,6 +27,7 @@ public:
                          const std::string& deviceHandleHint,
                          uint32_t chipIndex,
                          const std::vector<int>& channelIndexes,
+                         const std::string& dataFormat,
                          const std::string& linkFormat,
                          double sampleRate,
                          int rf_oversampling,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.cc
@@ -30,23 +30,11 @@ using namespace lime;
 namespace gr {
 namespace limesuiteng {
 
-static int GetDataFormatTypeSize(const std::string& formatname)
-{
-    if (formatname == "complex16_t")
-        return sizeof(lime::complex16_t);
-    else if (formatname == "complex12_t")
-        return sizeof(lime::complex12_t);
-    else if (formatname == "complex32f_t")
-        return sizeof(lime::complex32f_t);
-    else
-        return sizeof(lime::complex32f_t);
-}
-
 sdrdevice_sink::sptr sdrdevice_sink::make(const std::string& alias,
                                           const std::string& deviceHandleHint,
                                           uint32_t chipIndex,
                                           const std::vector<int>& channelIndexes,
-                                          const std::string& dataFormat,
+                                          const std::string& linkFormat,
                                           double sampleRate,
                                           int rf_oversampling)
 {
@@ -54,7 +42,7 @@ sdrdevice_sink::sptr sdrdevice_sink::make(const std::string& alias,
                                                           deviceHandleHint,
                                                           chipIndex,
                                                           channelIndexes,
-                                                          dataFormat,
+                                                          linkFormat,
                                                           sampleRate,
                                                           rf_oversampling);
 }
@@ -63,7 +51,7 @@ sdrdevice_sink_impl::sdrdevice_sink_impl(const std::string& alias,
                                          const std::string& deviceHandleHint,
                                          uint32_t chipIndex,
                                          const std::vector<int>& channelIndexes,
-                                         const std::string& dataFormat,
+                                         const std::string& linkFormat,
                                          double sampleRate,
                                          int rf_oversampling)
     : gr::sync_block((alias.empty()
@@ -71,14 +59,14 @@ sdrdevice_sink_impl::sdrdevice_sink_impl(const std::string& alias,
                           : alias),
                      gr::io_signature::make(1 /* min outputs */,
                                             channelIndexes.size() /*max outputs */,
-                                            GetDataFormatTypeSize(dataFormat)),
+                                            sizeof(lime::complex32f_t)),
                      gr::io_signature::make(0, 0, 0)),
       sdrdevice_block_base(TRXDir::Tx,
                            alias,
                            deviceHandleHint,
                            chipIndex,
                            channelIndexes,
-                           dataFormat,
+                           linkFormat,
                            sampleRate,
                            rf_oversampling,
                            d_logger,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.cc
@@ -34,6 +34,7 @@ sdrdevice_sink::sptr sdrdevice_sink::make(const std::string& alias,
                                           const std::string& deviceHandleHint,
                                           uint32_t chipIndex,
                                           const std::vector<int>& channelIndexes,
+                                          const std::string& dataFormat,
                                           const std::string& linkFormat,
                                           double sampleRate,
                                           int rf_oversampling)
@@ -42,6 +43,7 @@ sdrdevice_sink::sptr sdrdevice_sink::make(const std::string& alias,
                                                           deviceHandleHint,
                                                           chipIndex,
                                                           channelIndexes,
+                                                          dataFormat,
                                                           linkFormat,
                                                           sampleRate,
                                                           rf_oversampling);
@@ -51,6 +53,7 @@ sdrdevice_sink_impl::sdrdevice_sink_impl(const std::string& alias,
                                          const std::string& deviceHandleHint,
                                          uint32_t chipIndex,
                                          const std::vector<int>& channelIndexes,
+                                         const std::string& dataFormat,
                                          const std::string& linkFormat,
                                          double sampleRate,
                                          int rf_oversampling)
@@ -59,13 +62,16 @@ sdrdevice_sink_impl::sdrdevice_sink_impl(const std::string& alias,
                           : alias),
                      gr::io_signature::make(1 /* min outputs */,
                                             channelIndexes.size() /*max outputs */,
-                                            sizeof(lime::complex32f_t)),
+                                            (dataFormat == "complex16_t")
+                                                ? sizeof(lime::complex16_t)
+                                                : sizeof(lime::complex32f_t)),
                      gr::io_signature::make(0, 0, 0)),
       sdrdevice_block_base(TRXDir::Tx,
                            alias,
                            deviceHandleHint,
                            chipIndex,
                            channelIndexes,
+                           dataFormat,
                            linkFormat,
                            sampleRate,
                            rf_oversampling,
@@ -101,15 +107,24 @@ int sdrdevice_sink_impl::work(int noutput_items,
         StartRFStreaming();
     }
 
-    const lime::complex32f_t* samples[8];
-    for (size_t i = 0; i < devContext->streamCfg.channels.at(direction).size(); ++i)
-        samples[i] = static_cast<const lime::complex32f_t*>(input_items[i]);
-
     StreamTxMeta meta;
     meta.timestamp = lime::Timespec(0l);
     meta.hasTimestamp = false;
     meta.flags = 0; // StreamTxMeta::EndOfBurst;
-    int samplesSent = devContext->stream->Transmit(&samples[0], noutput_items, &meta);
+    int samplesSent;
+    const size_t chCount = devContext->streamCfg.channels.at(direction).size();
+
+    if (devContext->streamCfg.format == lime::DataFormat::I16) {
+        const lime::complex16_t* samples[8];
+        for (size_t i = 0; i < chCount; ++i)
+            samples[i] = static_cast<const lime::complex16_t*>(input_items[i]);
+        samplesSent = devContext->stream->Transmit(&samples[0], noutput_items, &meta);
+    } else {
+        const lime::complex32f_t* samples[8];
+        for (size_t i = 0; i < chCount; ++i)
+            samples[i] = static_cast<const lime::complex32f_t*>(input_items[i]);
+        samplesSent = devContext->stream->Transmit(&samples[0], noutput_items, &meta);
+    }
 
     if (samplesSent != noutput_items)
         GR_LOG_WARN(d_logger,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.cc
@@ -27,6 +27,16 @@
 
 using namespace lime;
 
+static int GetDataFormatTypeSize(const std::string& formatname)
+{
+    if (formatname == "complex16_t")
+        return sizeof(lime::complex16_t);
+    else if (formatname == "complex32f_t")
+        return sizeof(lime::complex32f_t);
+    else
+        return sizeof(lime::complex32f_t);
+}
+
 namespace gr {
 namespace limesuiteng {
 
@@ -62,9 +72,7 @@ sdrdevice_sink_impl::sdrdevice_sink_impl(const std::string& alias,
                           : alias),
                      gr::io_signature::make(1 /* min outputs */,
                                             channelIndexes.size() /*max outputs */,
-                                            (dataFormat == "complex16_t")
-                                                ? sizeof(lime::complex16_t)
-                                                : sizeof(lime::complex32f_t)),
+                                            GetDataFormatTypeSize(dataFormat)),
                      gr::io_signature::make(0, 0, 0)),
       sdrdevice_block_base(TRXDir::Tx,
                            alias,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.h
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.h
@@ -27,6 +27,7 @@ public:
                         const std::string& deviceHandleHint,
                         uint32_t chipIndex,
                         const std::vector<int>& channelIndexes,
+                        const std::string& dataFormat,
                         const std::string& linkFormat,
                         double sampleRate,
                         int rf_oversampling);

--- a/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.h
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_sink_impl.h
@@ -27,7 +27,7 @@ public:
                         const std::string& deviceHandleHint,
                         uint32_t chipIndex,
                         const std::vector<int>& channelIndexes,
-                        const std::string& dataFormat,
+                        const std::string& linkFormat,
                         double sampleRate,
                         int rf_oversampling);
     virtual ~sdrdevice_sink_impl();

--- a/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.cc
@@ -27,6 +27,16 @@
 
 using namespace lime;
 
+static int GetDataFormatTypeSize(const std::string& formatname)
+{
+    if (formatname == "complex16_t")
+        return sizeof(lime::complex16_t);
+    else if (formatname == "complex32f_t")
+        return sizeof(lime::complex32f_t);
+    else
+        return sizeof(lime::complex32f_t);
+}
+
 namespace gr {
 namespace limesuiteng {
 
@@ -63,8 +73,7 @@ sdrdevice_source_impl::sdrdevice_source_impl(const std::string& alias,
           gr::io_signature::make(0, 0, 0),
           gr::io_signature::make(1 /* min outputs */,
                                  channelIndexes.size() /*max outputs */,
-                                 (dataFormat == "complex16_t") ? sizeof(lime::complex16_t)
-                                                               : sizeof(lime::complex32f_t))),
+                                 GetDataFormatTypeSize(dataFormat))),
       sdrdevice_block_base(TRXDir::Rx,
                            alias,
                            deviceHandleHint,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.cc
@@ -30,23 +30,11 @@ using namespace lime;
 namespace gr {
 namespace limesuiteng {
 
-static int GetDataFormatTypeSize(const std::string& formatname)
-{
-    if (formatname == "complex16_t")
-        return sizeof(lime::complex16_t);
-    else if (formatname == "complex12_t")
-        return sizeof(lime::complex12_t);
-    else if (formatname == "complex32f_t")
-        return sizeof(lime::complex32f_t);
-    else
-        return sizeof(lime::complex32f_t);
-}
-
 sdrdevice_source::sptr sdrdevice_source::make(const std::string& alias,
                                               const std::string& deviceHandleHint,
                                               uint32_t chipIndex,
                                               const std::vector<int>& channelIndexes,
-                                              const std::string& dataFormat,
+                                              const std::string& linkFormat,
                                               double sampleRate,
                                               int rf_oversampling)
 {
@@ -54,7 +42,7 @@ sdrdevice_source::sptr sdrdevice_source::make(const std::string& alias,
                                                             deviceHandleHint,
                                                             chipIndex,
                                                             channelIndexes,
-                                                            dataFormat,
+                                                            linkFormat,
                                                             sampleRate,
                                                             rf_oversampling);
 }
@@ -63,7 +51,7 @@ sdrdevice_source_impl::sdrdevice_source_impl(const std::string& alias,
                                              const std::string& deviceHandleHint,
                                              uint32_t chipIndex,
                                              const std::vector<int>& channelIndexes,
-                                             const std::string& dataFormat,
+                                             const std::string& linkFormat,
                                              double sampleRate,
                                              int rf_oversampling)
     : gr::sync_block(
@@ -72,13 +60,13 @@ sdrdevice_source_impl::sdrdevice_source_impl(const std::string& alias,
           gr::io_signature::make(0, 0, 0),
           gr::io_signature::make(1 /* min outputs */,
                                  channelIndexes.size() /*max outputs */,
-                                 GetDataFormatTypeSize(dataFormat))),
+                                 sizeof(lime::complex32f_t))),
       sdrdevice_block_base(TRXDir::Rx,
                            alias,
                            deviceHandleHint,
                            chipIndex,
                            channelIndexes,
-                           dataFormat,
+                           linkFormat,
                            sampleRate,
                            rf_oversampling,
                            d_logger,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.cc
@@ -34,6 +34,7 @@ sdrdevice_source::sptr sdrdevice_source::make(const std::string& alias,
                                               const std::string& deviceHandleHint,
                                               uint32_t chipIndex,
                                               const std::vector<int>& channelIndexes,
+                                              const std::string& dataFormat,
                                               const std::string& linkFormat,
                                               double sampleRate,
                                               int rf_oversampling)
@@ -42,6 +43,7 @@ sdrdevice_source::sptr sdrdevice_source::make(const std::string& alias,
                                                             deviceHandleHint,
                                                             chipIndex,
                                                             channelIndexes,
+                                                            dataFormat,
                                                             linkFormat,
                                                             sampleRate,
                                                             rf_oversampling);
@@ -51,6 +53,7 @@ sdrdevice_source_impl::sdrdevice_source_impl(const std::string& alias,
                                              const std::string& deviceHandleHint,
                                              uint32_t chipIndex,
                                              const std::vector<int>& channelIndexes,
+                                             const std::string& dataFormat,
                                              const std::string& linkFormat,
                                              double sampleRate,
                                              int rf_oversampling)
@@ -60,12 +63,14 @@ sdrdevice_source_impl::sdrdevice_source_impl(const std::string& alias,
           gr::io_signature::make(0, 0, 0),
           gr::io_signature::make(1 /* min outputs */,
                                  channelIndexes.size() /*max outputs */,
-                                 sizeof(lime::complex32f_t))),
+                                 (dataFormat == "complex16_t") ? sizeof(lime::complex16_t)
+                                                               : sizeof(lime::complex32f_t))),
       sdrdevice_block_base(TRXDir::Rx,
                            alias,
                            deviceHandleHint,
                            chipIndex,
                            channelIndexes,
+                           dataFormat,
                            linkFormat,
                            sampleRate,
                            rf_oversampling,
@@ -101,12 +106,21 @@ int sdrdevice_source_impl::work(int noutput_items,
         StartRFStreaming();
     }
 
-    lime::complex32f_t* samples[8];
-    for (size_t i = 0; i < devContext->streamCfg.channels.at(direction).size(); ++i)
-        samples[i] = static_cast<lime::complex32f_t*>(output_items[i]);
-
     StreamRxMeta meta;
-    int samplesRead = devContext->stream->Receive(&samples[0], noutput_items, &meta);
+    int samplesRead;
+    const size_t chCount = devContext->streamCfg.channels.at(direction).size();
+
+    if (devContext->streamCfg.format == lime::DataFormat::I16) {
+        lime::complex16_t* samples[8];
+        for (size_t i = 0; i < chCount; ++i)
+            samples[i] = static_cast<lime::complex16_t*>(output_items[i]);
+        samplesRead = devContext->stream->Receive(&samples[0], noutput_items, &meta);
+    } else {
+        lime::complex32f_t* samples[8];
+        for (size_t i = 0; i < chCount; ++i)
+            samples[i] = static_cast<lime::complex32f_t*>(output_items[i]);
+        samplesRead = devContext->stream->Receive(&samples[0], noutput_items, &meta);
+    }
 
     if (samplesRead != noutput_items)
         GR_LOG_WARN(d_logger,

--- a/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.h
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.h
@@ -27,7 +27,7 @@ public:
                           const std::string& deviceHandleHint,
                           uint32_t chipIndex,
                           const std::vector<int>& channelIndexes,
-                          const std::string& dataFormat,
+                          const std::string& linkFormat,
                           double sampleRate,
                           int rf_oversampling);
     virtual ~sdrdevice_source_impl();

--- a/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.h
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_source_impl.h
@@ -27,6 +27,7 @@ public:
                           const std::string& deviceHandleHint,
                           uint32_t chipIndex,
                           const std::vector<int>& channelIndexes,
+                          const std::string& dataFormat,
                           const std::string& linkFormat,
                           double sampleRate,
                           int rf_oversampling);

--- a/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_sink_python.cc
+++ b/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_sink_python.cc
@@ -44,6 +44,7 @@ void bind_sdrdevice_sink(py::module& m)
              py::arg("deviceHandleHint"),
              py::arg("chipIndex"),
              py::arg("channelIndexes"),
+             py::arg("dataFormat") = "complex32f_t",
              py::arg("linkFormat") = "complex16_t",
              py::arg("sampleRate") = 10e6,
              py::arg("rf_oversampling") = 0,

--- a/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_sink_python.cc
+++ b/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_sink_python.cc
@@ -44,9 +44,9 @@ void bind_sdrdevice_sink(py::module& m)
              py::arg("deviceHandleHint"),
              py::arg("chipIndex"),
              py::arg("channelIndexes"),
-             py::arg("dataFormat"),
-             py::arg("sampleRate"),
-             py::arg("rf_oversampling"),
+             py::arg("linkFormat") = "complex16_t",
+             py::arg("sampleRate") = 10e6,
+             py::arg("rf_oversampling") = 0,
              D(sdrdevice_sink, make))
 
 

--- a/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_source_python.cc
+++ b/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_source_python.cc
@@ -45,6 +45,7 @@ void bind_sdrdevice_source(py::module& m)
              py::arg("deviceHandleHint"),
              py::arg("chipIndex"),
              py::arg("channelIndexes"),
+             py::arg("dataFormat") = "complex32f_t",
              py::arg("linkFormat") = "complex16_t",
              py::arg("sampleRate") = 10e6,
              py::arg("rf_oversampling") = 0,

--- a/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_source_python.cc
+++ b/plugins/gr-limesuiteng/python/limesuiteng/bindings/sdrdevice_source_python.cc
@@ -45,9 +45,9 @@ void bind_sdrdevice_source(py::module& m)
              py::arg("deviceHandleHint"),
              py::arg("chipIndex"),
              py::arg("channelIndexes"),
-             py::arg("dataFormat"),
-             py::arg("sampleRate"),
-             py::arg("rf_oversampling"),
+             py::arg("linkFormat") = "complex16_t",
+             py::arg("sampleRate") = 10e6,
+             py::arg("rf_oversampling") = 0,
              D(sdrdevice_source, make))
 
 


### PR DESCRIPTION
gr-limesuiteng: linkFormat and gr output issues

The gr-limesuiteng GNURadio blocks (sdrdevice_source / sdrdevice_sink) previously had two bugs and one missing feature:

 ## Bug 1 — linkFormat was hardcoded to I16
sdrdevice_block_base.cc unconditionally set streamCfg.linkFormat = DataFormat::I16 regardless of what the user configured. This meant the XTRX (and other LimeSuiteNG devices) always used 4 bytes/sample on the PCIe DMA bus, making 120 MSPS SISO impossible on a PCIe Gen2 x1 link (~400 MB/s limit: I16 needs 480 MB/s, I12 needs only 360 MB/s).

 ## Bug 2 — dataFormat parameter created type mismatch
The sc16 option advertised a 4-byte output port but work() unconditionally wrote 8 bytes (F32) into it — a silent buffer overflow causing garbage output and GNURadio port type mismatch errors when connecting to downstream fc32 blocks.

 ## Fix
  - streamCfg.format is now hardcoded to F32. The GNURadio ports are always fc32. TRXLooper handles the integer→float
  conversion internally before Receive() returns — this is a CPU SIMD operation, not a bottleneck.
  - linkFormat is now a user-configurable parameter (complex16_t = I16 default, complex12_t = I12 for PCIe bandwidth
  saving). Setting I12 writes the FPGA register 0x0008 to pack samples as 3 bytes/IQ pair and programs the DMA
  transfer size accordingly — real hardware behavior, not a software conversion.
  - The old dataFormat parameter is removed entirely. The link_format GRC block parameter replaces it.

## changelog 

  - plugins/gr-limesuiteng/
      - lib/sdrdevice_block_base.h/.cc       — removed dataFormat, added linkFormat, hardcoded format=F32
      - lib/sdrdevice_source_impl.h/.cc      — removed dataFormat, io_signature always sizeof(complex32f_t)
      - lib/sdrdevice_sink_impl.h/.cc        — same
      - include/gnuradio/limesuiteng/
      - sdrdevice_source.h                 — updated make() signature, added docs
      - sdrdevice_sink.h                   — same
   - python/limesuiteng/bindings/
      - sdrdevice_source_python.cc         — updated pybind11 args
      - sdrdevice_sink_python.cc           — same
   - grc/
      - limesuiteng_sdrdevice_source.block.yml  — removed data_format, output hardcoded fc32
      - limesuiteng_sdrdevice_sink.block.yml    — same

  