### PR TITLE
Fix sample conversion hang at 65536 or more samples

### DIFF
--- a/src/streaming/samplesConversion.h
+++ b/src/streaming/samplesConversion.h
@@ -91,7 +91,7 @@ template<uint32_t srcCount, class DestT, class SrcT> static void fastPath_conver
 // dynamic iteration count, will generate extra SIMD instructions for various last iteration counts
 template<class DestT, class SrcT> static void slowPath_convert(DestT* dest, const SrcT* src, uint32_t srcCount)
 {
-    for (uint16_t i = 0; i < srcCount; ++i)
+    for (uint32_t i = 0; i < srcCount; ++i)
         Rescale(dest[i], src[i]);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(${TESTS_CONTAINER_TARGET} PRIVATE TestEntry.cpp)
 target_sources(
     ${TESTS_CONTAINER_TARGET}
     PRIVATE comms/SPI_utilities_tests.cpp
+            streaming/samplesConversion_tests.cpp
             streaming/Timespec_tests.cpp
             # parsers/CoefficientFileParserTest.cpp
             protocols/BufferInterleavingTest.cpp)

--- a/tests/streaming/samplesConversion_tests.cpp
+++ b/tests/streaming/samplesConversion_tests.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+
+#include "streaming/samplesConversion.h"
+
+#include <vector>
+
+using namespace lime;
+
+// srcCount of 65536 or more used to hang: the loop counter was 16 bit and
+// wrapped to 0 before ever reaching the bound (issue #195).
+TEST(SamplesConversion, SlowPathConvertHandlesCountsAbove16bitRange)
+{
+    constexpr uint32_t srcCount = 65537;
+    std::vector<complex16_t> src(srcCount);
+    std::vector<complex32f_t> dest(srcCount);
+    src.front() = complex16_t(-32768, 16384);
+    src.back() = complex16_t(16384, -32768);
+
+    slowPath_convert(dest.data(), src.data(), srcCount);
+
+    EXPECT_FLOAT_EQ(dest.front().real(), -1.0f);
+    EXPECT_FLOAT_EQ(dest.front().imag(), 0.5f);
+    EXPECT_FLOAT_EQ(dest.back().real(), 0.5f);
+    EXPECT_FLOAT_EQ(dest.back().imag(), -1.0f);
+}


### PR DESCRIPTION
slowPath_convert in src/streaming/samplesConversion.h used a uint16_t loop counter against a uint32_t count, so at 65536 samples the counter wrapped and the loop never ended. One word fix plus the unit test that would have caught it.

Fixes #195. Root cause behind the symptom in #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
