### PR TITLE
Bound the control command Busy retry loop

### DIFF
--- a/src/protocols/LMS64CProtocol.cpp
+++ b/src/protocols/LMS64CProtocol.cpp
@@ -201,6 +201,9 @@ static constexpr std::array<char, 16> ADC_UNITS_PREFIX = {
 static OpStatus RunControlCommand(ISerialPort& port, uint8_t* request, uint8_t* response, size_t length, int timeout_ms = 100)
 {
     OpStatus status;
+    // Busy means the control channel is temporarily unavailable. Retry, but
+    // only until the timeout, so an unresponsive device cannot hang the host.
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
     do
     {
 #if DEBUG_SPI
@@ -211,7 +214,7 @@ static OpStatus RunControlCommand(ISerialPort& port, uint8_t* request, uint8_t* 
 
         lime::log(LogLevel::Debug, "Rd:"s + BufferToString(response, length));
 #endif
-    } while (status == OpStatus::Busy);
+    } while (status == OpStatus::Busy && std::chrono::steady_clock::now() < deadline);
 
     if (status != OpStatus::Success)
         return status;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,8 @@ target_sources(
     PRIVATE comms/SPI_utilities_tests.cpp
             streaming/Timespec_tests.cpp
             # parsers/CoefficientFileParserTest.cpp
-            protocols/BufferInterleavingTest.cpp)
+            protocols/BufferInterleavingTest.cpp
+            protocols/LMS64CProtocol/ControlCommandBusyTest.cpp)
 
 add_subdirectory(embedded/lms7002m)
 

--- a/tests/protocols/LMS64CProtocol/ControlCommandBusyTest.cpp
+++ b/tests/protocols/LMS64CProtocol/ControlCommandBusyTest.cpp
@@ -1,0 +1,55 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "comms/ISerialPort.h"
+#include "protocols/LMS64CProtocol.h"
+
+using namespace lime;
+using ::testing::_;
+using ::testing::Invoke;
+using ::testing::Return;
+
+namespace {
+
+class MockSerialPort : public ISerialPort
+{
+  public:
+    MOCK_METHOD(int, Write, (const uint8_t*, std::size_t, int), (override));
+    MOCK_METHOD(int, Read, (uint8_t*, std::size_t, int), (override));
+    MOCK_METHOD(OpStatus, RunControlCommand, (uint8_t*, size_t, int), (override));
+    MOCK_METHOD(OpStatus, RunControlCommand, (uint8_t*, uint8_t*, size_t, int), (override));
+};
+
+} // namespace
+
+// The retry loop used to spin forever when the transport kept reporting
+// Busy, hanging the host with no error (issue #203).
+TEST(LMS64CProtocol, ControlCommandStopsRetryingBusyAfterTimeout)
+{
+    MockSerialPort port;
+    EXPECT_CALL(port, RunControlCommand(_, _, _, _)).WillRepeatedly(Return(OpStatus::Busy));
+
+    LMS64CProtocol::FirmwareInfo info{};
+    const auto start = std::chrono::steady_clock::now();
+    const OpStatus status = LMS64CProtocol::GetFirmwareInfo(port, info, 0);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_EQ(status, OpStatus::Busy);
+    EXPECT_LT(elapsed, std::chrono::seconds(5));
+}
+
+TEST(LMS64CProtocol, ControlCommandRetriesBusyThenSucceeds)
+{
+    MockSerialPort port;
+    EXPECT_CALL(port, RunControlCommand(_, _, _, _))
+        .WillOnce(Return(OpStatus::Busy))
+        .WillOnce(Invoke([](uint8_t*, uint8_t* response, size_t, int) {
+            reinterpret_cast<LMS64CPacket*>(response)->status = LMS64CProtocol::CommandStatus::Completed;
+            return OpStatus::Success;
+        }));
+
+    LMS64CProtocol::FirmwareInfo info{};
+    EXPECT_EQ(LMS64CProtocol::GetFirmwareInfo(port, info, 0), OpStatus::Success);
+}


### PR DESCRIPTION
RunControlCommand in LMS64CProtocol.cpp retried forever while the transport reported Busy, hanging the host with no error. The retry loop now stops at the callers timeout and returns Busy. Unit tests cover the bound and the preserved retry behaviour.

Fixes #203.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
