### PR TITLE
Fix division by zero crash in TX calibration

### DIFF
--- a/embedded/lms7002m/calibrations.c
+++ b/embedded/lms7002m/calibrations.c
@@ -1056,7 +1056,7 @@ static lime_Result lms7002m_check_saturation_tx_rx(lms7002m_context* self, uint3
             lms7002m_spi_modify_csr(self, LMS7002M_G_PGA_RBB, g_pga);
             rssi = lms7002m_get_rssi(self);
             //if ((float)rssi / rssi_prev < 1.05) // pga should give ~1dB change
-            if ((rssi * 100) / rssi_prev < 105) // pga should give ~1dB change
+            if (rssi_prev != 0 && (rssi * 100) / rssi_prev < 105) // pga should give ~1dB change
                 break;
 
             rssi_prev = rssi;

--- a/tests/embedded/lms7002m/lms7002m_embedded_tests.cpp
+++ b/tests/embedded/lms7002m/lms7002m_embedded_tests.cpp
@@ -216,3 +216,21 @@ TEST_F(lms7002m_embedded, lms7002m_set_frequency_sx_SetGet_ValueMatch)
     ASSERT_EQ(lms7002m_set_frequency_sx(chip, isTx, expectedFreq), lime_Result_Success);
     EXPECT_NEAR(lms7002m_get_frequency_sx(chip, isTx), expectedFreq, 10);
 }
+
+// TX calibration used to crash with a division by zero when the measured
+// RSSI is 0, for example with no signal present (issue #156). The stub
+// reads RSSI registers as 0, which exercises exactly that condition.
+TEST_F(lms7002m_embedded, lms7002m_calibrate_tx_ZeroRssi_FailsInsteadOfCrashing)
+{
+    ASSERT_EQ(lms7002m_set_reference_clock(chip, 30720000), lime_Result_Success);
+    ASSERT_EQ(lms7002m_set_active_channel(chip, LMS7002M_CHANNEL_A), lime_Result_Success);
+    spi_stub.Set(0, { 0x008C, 13, 12 }, 2); // force CGEN tune success
+    spi_stub.Set(0, { 0x0123, 13, 12 }, 2); // force SX RX tune success
+    spi_stub.Set(1, { 0x0123, 13, 12 }, 2); // force SX TX tune success
+    spi_stub.Set(0, { 0x0103, 11, 10 }, 1); // select Tx BAND1
+    ASSERT_EQ(lms7002m_set_frequency_sx(chip, true, 1400000000), lime_Result_Success);
+
+    const lime_Result result = lms7002m_calibrate_tx(chip, 5000000, false);
+
+    ASSERT_NE(result, lime_Result_Success);
+}

--- a/tests/embedded/lms7002m/lms7002m_embedded_tests.h
+++ b/tests/embedded/lms7002m/lms7002m_embedded_tests.h
@@ -62,16 +62,17 @@ class LMS7002M_SPI_STUB
                 addr &= 0x7FFF; // clear write bit for now
                 uint16_t value = mosi[i] & 0xFFFF;
 
-                // prevent writing to read only bits
+                // writes cannot change read only bits, they keep their current value
+                uint16_t writableMask = 0xFFFF;
                 auto iter = self->readOnlyRegisterMasks.find(addr);
                 if (iter != self->readOnlyRegisterMasks.end())
-                    value &= iter->second;
+                    writableMask = iter->second;
 
                 uint8_t mac = self->registers[0].at(0x0020) & 0x3;
                 if (mac & 0x1 || addr < 0x0100)
-                    self->registers[0][addr] = value;
+                    self->registers[0][addr] = (self->registers[0][addr] & ~writableMask) | (value & writableMask);
                 if (mac & 0x2 && addr >= 0x0100)
-                    self->registers[1][addr] = value;
+                    self->registers[1][addr] = (self->registers[1][addr] & ~writableMask) | (value & writableMask);
                 ++self->writeCount;
             }
             else


### PR DESCRIPTION
The receiver saturation search in embedded/lms7002m/calibrations.c divided by the previous RSSI reading without checking for zero, so TX calibration crashed the host application with SIGFPE when no signal was measured. One line guard: the relative change check is skipped when the previous reading is zero, and calibration reports failure instead of crashing.

Includes a regression test that reproduces the crash through the SPI stub, plus a stub correction so chip writes keep read only register bits like real hardware does.

Fixes #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
