### PR TITLE
Add board check script and runbook

### DIFF
--- a/tools/board-check/RUNBOOK.md
+++ b/tools/board-check/RUNBOOK.md
@@ -1,0 +1,36 @@
+# Board check runbook
+
+`board_check.sh` verifies that a connected LimeSDR board works with
+this LimeSuiteNG build: it enumerates, reports its identity, accepts
+configuration and streams samples. No antennas or signal generators
+are needed, the streaming step uses the chip test signal. It stops at
+the first failing step and ends with PASS or FAIL; the exit code is 0
+only on PASS. Takes about a minute. Connect one board at a time.
+
+## Prerequisites
+
+1. LimeSuiteNG installed, so that `limeDevice`, `limeConfig` and
+   `limeTRX` are in PATH.
+2. PCIe boards (XTRX, X3): the limepcie kernel driver loaded,
+   check with `lsmod | grep limepcie`.
+3. USB boards (Mini, USB): udev rules installed
+   (`udev-rules/install.sh`), then replug the board.
+
+## Running
+
+    tools/board-check/board_check.sh
+
+## When a step fails
+
+- Step 1: check cabling, `lsusb` or `lspci`, driver and udev rules.
+  A board that never enumerates is a setup problem, not a software bug.
+- Steps 2 to 4: rerun the failing command by hand with `--log debug`
+  and attach its output plus `limeDevice --full` to an issue at
+  https://github.com/myriadrf/LimeSuiteNG/issues
+
+## Release candidate check
+
+Before promoting a release candidate to final: install the rc
+packages on a clean machine, run this script against a real board.
+PASS: promote. FAIL: file the issue, fix, build new rc packages,
+repeat.

--- a/tools/board-check/board_check.sh
+++ b/tools/board-check/board_check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# LimeSuiteNG board check. Runs each step in order and stops at the
+# first failure, so the last printed step is the one that failed.
+# Exit code 0 means the board passed. See RUNBOOK.md for details.
+
+set -e
+trap 'echo "FAIL"' ERR
+
+echo "1. Board enumerates"
+limeDevice
+
+echo "2. Identity readable"
+limeDevice --full
+
+echo "3. Configuration accepted: 10 MHz sample rate, 1 GHz LO, Rx test signal"
+limeConfig --initialize --samplerate 10e6 --rxen 1 --rxlo 1e9 --rxtestsignal 1
+
+echo "4. Rx streaming works: 2 seconds through the whole digital path"
+limeTRX --time 2000
+
+echo "PASS"


### PR DESCRIPTION
Adds tools/board-check: a short script that verifies a connected board end to end with the shipped CLI tools (enumeration, identity, configuration, streaming with the chip test signal, so no antennas needed), plus a runbook with prerequisites, failure triage and the release candidate check procedure. Stops at the first failing step, prints PASS or FAIL, exit code 0 only on pass.

Fixes #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
