### PR TITLE
Do not deploy docs on pull request runs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -38,9 +38,10 @@ jobs:
           ./generate_docs.sh rebuild
 
       - name: Deploy to Cloudflare Worker
+        if: github.event_name == 'push'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CF_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT }}
           wranglerVersion: "4"
-          command: ${{ github.event_name == 'pull_request' && 'versions upload' || 'deploy' }}
+          command: deploy


### PR DESCRIPTION
The Cloudflare deploy step ran on every pull request build and always failed on fork PRs, where secrets are not available. Pull requests now only build the documentation, deployment happens only on pushes to develop. Two changed lines, validated with actionlint.

Fixes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
