### PR TITLE
Honor requested stream FIFO size, report status in samples

### DIFF
--- a/src/include/limesuiteng/StreamConfig.h
+++ b/src/include/limesuiteng/StreamConfig.h
@@ -77,7 +77,7 @@ struct LIME_API StreamConfig {
     DataFormat format; ///< Samples format used for Read/Write functions
     DataFormat linkFormat; ///< Samples format used in transport layer Host<->FPGA
 
-    /// @brief Memory size to allocate for each channel buffering.
+    /// @brief Requested FIFO size (in samples) for each channel buffering.
     /// Default: 0 - allow to decide internally.
     uint32_t bufferSize;
 

--- a/src/streaming/TRXLooper.cpp
+++ b/src/streaming/TRXLooper.cpp
@@ -499,7 +499,11 @@ OpStatus TRXLooper::RxSetup()
     assert(mRxArgs.packetsToBatch > 0);
     assert(mRxArgs.samplesInPacket > 0);
 
-    const int packetsInFIFO = 0.25 * mConfig.hintSampleRate / (mRx.samplesInPkt * mRx.packetsToBatch); // buffer 0.25 second of data
+    const uint32_t rxPacketSamples = mRx.samplesInPkt * mRx.packetsToBatch;
+    int packetsInFIFO = 0.25 * mConfig.hintSampleRate / rxPacketSamples; // buffer 0.25 second of data
+    // honor the requested FIFO size (in samples), the pool needs 2 extra packets for staging
+    if (mConfig.bufferSize > 0)
+        packetsInFIFO = (mConfig.bufferSize + rxPacketSamples - 1) / rxPacketSamples + 2;
     mRx.packetsPool = std::make_unique<MTStack<StreamPacket*>>(packetsInFIFO);
     const uint32_t userSampleSize = mConfig.format == DataFormat::F32 ? sizeof(lime::complex32f_t) : sizeof(lime::complex16_t);
     for (uint32_t i = 0; i < mRx.packetsPool->capacity(); ++i)
@@ -1131,7 +1135,11 @@ OpStatus TRXLooper::TxSetup()
             mCallback_logMessage(LogLevel::Verbose, msg);
     }
 
-    const int packetsInFIFO = 0.25 * mConfig.hintSampleRate / (mTx.packetsToBatch * mTx.samplesInPkt); // buffer 0.25 second of data
+    const uint32_t txPacketSamples = mTx.packetsToBatch * mTx.samplesInPkt;
+    int packetsInFIFO = 0.25 * mConfig.hintSampleRate / txPacketSamples; // buffer 0.25 second of data
+    // honor the requested FIFO size (in samples), the pool needs 2 extra packets for staging
+    if (mConfig.bufferSize > 0)
+        packetsInFIFO = (mConfig.bufferSize + txPacketSamples - 1) / txPacketSamples + 2;
     mTx.packetsPool = std::make_unique<MTStack<StreamPacket*>>(packetsInFIFO);
     const uint32_t userSampleSize = mConfig.format == DataFormat::F32 ? sizeof(lime::complex32f_t) : sizeof(lime::complex16_t);
     for (uint32_t i = 0; i < mTx.packetsPool->capacity(); ++i)
@@ -1692,8 +1700,12 @@ void TRXLooper::StreamStatus(StreamStats* rxStats, StreamStats* txStats)
     if (txStats)
     {
         *txStats = mTx.stats;
+        // FIFO holds sample packets, report the counts in samples
         if (mTx.fifo)
-            txStats->FIFO = { mTx.fifo->max_size(), mTx.fifo->size() };
+        {
+            const std::size_t txPacketSamples = mTx.packetsToBatch * mTx.samplesInPkt;
+            txStats->FIFO = { mTx.fifo->max_size() * txPacketSamples, mTx.fifo->size() * txPacketSamples };
+        }
         else
             txStats->FIFO = { 1, 0 };
     }
@@ -1701,7 +1713,10 @@ void TRXLooper::StreamStatus(StreamStats* rxStats, StreamStats* txStats)
     {
         *rxStats = mRx.stats;
         if (mRx.fifo)
-            rxStats->FIFO = { mRx.fifo->max_size(), mRx.fifo->size() };
+        {
+            const std::size_t rxPacketSamples = mRx.packetsToBatch * mRx.samplesInPkt;
+            rxStats->FIFO = { mRx.fifo->max_size() * rxPacketSamples, mRx.fifo->size() * rxPacketSamples };
+        }
         else
             rxStats->FIFO = { 1, 0 };
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ target_sources(
     PRIVATE comms/SPI_utilities_tests.cpp
             streaming/samplesConversion_tests.cpp
             streaming/Timespec_tests.cpp
+            streaming/TRXLooper_tests.cpp
             # parsers/CoefficientFileParserTest.cpp
             protocols/BufferInterleavingTest.cpp
             protocols/LMS64CProtocol/ControlCommandBusyTest.cpp)

--- a/tests/streaming/TRXLooper_tests.cpp
+++ b/tests/streaming/TRXLooper_tests.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "FPGA/FPGA_common.h"
+#include "comms/IDMA.h"
+#include "comms/SPI/ISPI.h"
+#include "limesuiteng/LMS7002M.h"
+#include "limesuiteng/OpStatus.h"
+#include "limesuiteng/StreamConfig.h"
+#include "streaming/TRXLooper.h"
+
+using namespace lime;
+
+namespace {
+
+// Answers all SPI traffic with zeroes, enough for TRXLooper::Setup to pass
+class SPIStub : public ISPI
+{
+  public:
+    OpStatus Transact(const uint32_t* MOSI, uint32_t* MISO, uint32_t count) override
+    {
+        if (MISO != nullptr)
+            std::memset(MISO, 0, count * sizeof(uint32_t));
+        return OpStatus::Success;
+    }
+};
+
+// Provides fake DMA buffers, all operations succeed without a device
+class DMAStub : public IDMA
+{
+  public:
+    DMAStub()
+        : memory(bufferCount * bufferSize)
+    {
+    }
+    OpStatus Initialize() override { return OpStatus::Success; }
+    OpStatus Enable(bool enabled) override { return OpStatus::Success; }
+    OpStatus EnableContinuous(bool enabled, uint32_t maxTransferSize, uint8_t irqPeriod) override { return OpStatus::Success; }
+    State GetCounters() override { return { 0 }; }
+    OpStatus SubmitRequest(uint64_t index, uint32_t bytesCount, DataTransferDirection dir, bool irq) override
+    {
+        return OpStatus::Success;
+    }
+    OpStatus Wait() override { return OpStatus::Success; }
+    void BufferOwnership(uint16_t index, DataTransferDirection dir) override {}
+    std::vector<Buffer> GetBuffers() const override
+    {
+        std::vector<Buffer> buffers;
+        for (uint32_t i = 0; i < bufferCount; ++i)
+            buffers.push_back({ const_cast<uint8_t*>(memory.data()) + i * bufferSize, bufferSize });
+        return buffers;
+    }
+    std::string GetName() const override { return "DMAStub"; }
+
+  private:
+    static constexpr uint32_t bufferCount = 8;
+    static constexpr uint32_t bufferSize = 8192;
+    std::vector<uint8_t> memory;
+};
+
+StreamConfig MakeConfig(TRXDir dir, uint32_t requestedFIFOSize)
+{
+    StreamConfig cfg;
+    cfg.channels.at(dir).push_back(0);
+    cfg.format = DataFormat::I16;
+    cfg.linkFormat = DataFormat::I16;
+    cfg.hintSampleRate = 10e6;
+    cfg.bufferSize = requestedFIFOSize;
+    return cfg;
+}
+
+} // namespace
+
+namespace lime::testing {
+
+TEST(TRXLooperFIFO, TxFIFOSizeHonorsRequest)
+{
+    auto spi = std::make_shared<SPIStub>();
+    FPGA fpga(spi, spi);
+    LMS7002M lms(spi);
+    TRXLooper looper(std::make_shared<DMAStub>(), std::make_shared<DMAStub>(), &fpga, &lms, 0);
+
+    constexpr uint32_t requestedSamples = 129600;
+    ASSERT_EQ(looper.Setup(MakeConfig(TRXDir::Tx, requestedSamples)), OpStatus::Success);
+
+    StreamStats stats{};
+    looper.StreamStatus(nullptr, &stats);
+    EXPECT_GE(stats.FIFO.totalCount, requestedSamples);
+    // the size can be rounded up to whole packets, but not more
+    EXPECT_LE(stats.FIFO.totalCount, requestedSamples + 8192);
+}
+
+TEST(TRXLooperFIFO, RxFIFOSizeHonorsRequest)
+{
+    auto spi = std::make_shared<SPIStub>();
+    FPGA fpga(spi, spi);
+    LMS7002M lms(spi);
+    TRXLooper looper(std::make_shared<DMAStub>(), std::make_shared<DMAStub>(), &fpga, &lms, 0);
+
+    constexpr uint32_t requestedSamples = 129600;
+    ASSERT_EQ(looper.Setup(MakeConfig(TRXDir::Rx, requestedSamples)), OpStatus::Success);
+
+    StreamStats stats{};
+    looper.StreamStatus(&stats, nullptr);
+    EXPECT_GE(stats.FIFO.totalCount, requestedSamples);
+    EXPECT_LE(stats.FIFO.totalCount, requestedSamples + 8192);
+}
+
+} // namespace lime::testing


### PR DESCRIPTION
StreamConfig::bufferSize was not consumed anywhere, so the fifoSize requested through the legacy API was ignored, and LMS_GetStreamStatus reported FIFO counts in packet batches instead of samples. Size the Rx/Tx FIFOs from the request when it is given (0 keeps the current automatic sizing) and report the counts in samples.

Verified with new unit tests that run TRXLooper on SPI and DMA stubs, no hardware needed: before the fix a 129600 sample request reported totalCount 1223, after the fix 130560 (rounded up to whole packets).

Fixes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)