### PR TITLE
Upload Windows build binaries as CI artifacts

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -77,6 +77,15 @@ jobs:
       - name: Install
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel ${{env.CMAKE_BUILD_PARALLEL_LEVEL}} --target install
 
+      - name: Stage install for artifact
+        run: cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --prefix ${{github.workspace}}/artifact
+
+      - name: Upload Windows binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: limesuiteng-windows-${{matrix.arch}}
+          path: ${{github.workspace}}/artifact
+
   build-MacOS:
     name: MacOS build
     runs-on: macos-latest


### PR DESCRIPTION
The Windows CI job builds limesuiteng.dll, the legacy API, limeGUI and all the CLI tools for x64 and Win32, but nothing was published. Stage the install into a folder and upload it as a workflow artifact, so every run provides downloadable Windows binaries. Proper user facing installers remain part of the release packaging tasks.

Verified: downloaded the limesuiteng-windows-x64 artifact from this PR run and ran the tools on a Windows 11 machine, limeDevice.exe executes and reports no devices as expected without hardware. The artifact also includes limeGUI.exe with the wxWidgets runtime DLLs.

Part of #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)