### PR TITLE
Write captured samples to file in the FFT viewer

### DIFF
--- a/GUI/fftviewer_wxgui/fftviewer_frFFTviewer.cpp
+++ b/GUI/fftviewer_wxgui/fftviewer_frFFTviewer.cpp
@@ -481,18 +481,35 @@ void fftviewer_frFFTviewer::StreamingLoop(
 
         if (pthis->captureSamples.load())
         {
+            const uint32_t samplesToCopy = min(samplesPopped, samplesToCapture);
             for (int ch = 0; ch < channelsCount; ++ch)
             {
-                uint32_t samplesToCopy = min(samplesPopped, samplesToCapture);
-                if (samplesToCopy <= 0)
-                    break;
                 for (uint32_t i = 0; i < samplesToCopy; ++i)
                 {
                     captureBuffer[ch][samplesCaptured + i].real(buffers[ch][i].real() * 32767);
                     captureBuffer[ch][samplesCaptured + i].imag(buffers[ch][i].imag() * 32767);
                 }
-                samplesToCapture -= samplesToCopy;
-                samplesCaptured += samplesToCopy;
+            }
+            samplesToCapture -= samplesToCopy;
+            samplesCaptured += samplesToCopy;
+
+            if (samplesToCapture == 0)
+            {
+                // capture complete, write the samples to the selected file
+                std::ofstream fout(pthis->captureFilename);
+                fout << "AI\tAQ";
+                if (channelsCount > 1)
+                    fout << "\tBI\tBQ";
+                fout << "\n";
+                for (uint32_t i = 0; i < samplesCaptured; ++i)
+                {
+                    fout << static_cast<int>(captureBuffer[0][i].real()) << "\t" << static_cast<int>(captureBuffer[0][i].imag());
+                    if (channelsCount > 1)
+                        fout << "\t" << static_cast<int>(captureBuffer[1][i].real()) << "\t"
+                             << static_cast<int>(captureBuffer[1][i].imag());
+                    fout << "\n";
+                }
+                pthis->captureSamples.store(false);
             }
         }
 


### PR DESCRIPTION
The FFT viewer capture loop filled captureBuffer but no code ever wrote it to the file chosen in the save dialog, so the capture silently produced nothing and never finished. The shared sample counters also advanced inside the per channel loop, corrupting two channel captures.

The samples are now written as tab separated text (AI AQ, plus BI BQ for two channels) once the requested count is reached, and the capture stops.

Verified the exact old and new logic in a standalone harness with synthetic two channel data arriving in uneven chunks: the old code corrupted the channel data and wrote nothing, the fixed code writes every value correctly. A quick run with a board would be a welcome confirmation, streaming in the viewer needs a device.

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)