### PR TITLE
docs: update class diagrams to the current code structure

### DIFF
--- a/docs/developer/Introduction/device_class.mmd
+++ b/docs/developer/Introduction/device_class.mmd
@@ -11,6 +11,7 @@ classDiagram
     class LMS7002M {<<Interface>>}
 
     class LimeSDR_Mini
+    class LimeNET_Micro
     class LimeSDR
     class LimeSDR_XTRX
     class LimeSDR_X3
@@ -28,6 +29,7 @@ classDiagram
     SDRDevice<|--LMS7002M_SDRDevice
     SDRDevice<|--LimeSDR_MMX8
     LMS7002M_SDRDevice<|--LimeSDR_Mini
+    LMS7002M_SDRDevice<|--LimeNET_Micro
     LMS7002M_SDRDevice<|--LimeSDR
     LMS7002M_SDRDevice<|--LimeSDR_XTRX
     LMS7002M_SDRDevice<|--LimeSDR_X3
@@ -39,6 +41,7 @@ classDiagram
     %% Class associations
     FPGA-->LimeSDR
     FPGA_Mini-->LimeSDR_Mini
+    FPGA_Mini-->LimeNET_Micro
     FPGA_X3-->LimeSDR_X3
     FPGA_XTRX-->LimeSDR_XTRX
     FPGA_XTRX-->sSDR
@@ -51,6 +54,9 @@ classDiagram
 
     %% LimeSDR Mini
     LimeSDR_Mini..>ISerialPort
+
+    %% LimeNET Micro
+    LimeNET_Micro..>ISerialPort
 
     %% LimeSDR
     LimeSDR..>ISerialPort

--- a/docs/developer/Introduction/streaming_class.dox
+++ b/docs/developer/Introduction/streaming_class.dox
@@ -29,5 +29,6 @@
  * - Solid line with a transparent arrow head body - Inheritance
  * - Dotted line with simple arrow head - Dependency
  * - Solid line with simple arrow head - Association
- * 
+ * - Solid line with a hollow diamond - Aggregation
+ *
  */

--- a/docs/developer/Introduction/streaming_class.mmd
+++ b/docs/developer/Introduction/streaming_class.mmd
@@ -9,6 +9,8 @@ classDiagram
 
     class RFStream {<<Interface>>}
     class TRXLooper
+    class StreamComposite
+    class RFStream_X8
 
     class IDMA {<<Interface>>}
     class LMS7002M {<<Interface>>}
@@ -17,6 +19,11 @@ classDiagram
 
     %% Inheritance
     RFStream<|--TRXLooper
+    RFStream<|--StreamComposite
+    RFStream<|--RFStream_X8
+
+    %% Aggregation
+    StreamComposite o-- RFStream
 
     %% Dependencies
     TRXLooper..>IDMA


### PR DESCRIPTION
Updates the maintained mermaid class diagrams in the developer introduction: adds LimeNET_Micro to the device class diagram, and StreamComposite plus RFStream_X8 to the streaming class diagram, with the aggregation link described in the legend. All added relations match the current class declarations.

Note: the doxygen only fallback PNG images on these pages predate the 1.0 refactor and are still stale. The published docs render the mermaid path, so they are not visible there. Regenerating them needs mermaid-cli, worth deciding whether to keep the fallback at all.

Part of #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)