### PR TITLE
boards: select the channel and validate count in GFIR coefficient access

### DIFF
--- a/src/boards/LMS7002M_SDRDevice.cpp
+++ b/src/boards/LMS7002M_SDRDevice.cpp
@@ -927,6 +927,7 @@ ChannelConfig::Direction::TestSignal LMS7002M_SDRDevice::GetTestSignal(uint8_t m
 std::vector<double> LMS7002M_SDRDevice::GetGFIRCoefficients(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t gfirID)
 {
     auto& lms = mLMSChips.at(moduleIndex);
+    LMS7002M::ChannelScope scope(lms.get(), static_cast<uint8_t>(channel % 2));
 
     const uint8_t count = gfirID == 2 ? 120 : 40;
     std::vector<double> coefficientBuffer(count);
@@ -939,8 +940,20 @@ std::vector<double> LMS7002M_SDRDevice::GetGFIRCoefficients(uint8_t moduleIndex,
 OpStatus LMS7002M_SDRDevice::SetGFIRCoefficients(
     uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t gfirID, std::vector<double> coefficients)
 {
+    if (gfirID > 2)
+        return ReportError(OpStatus::OutOfRange, "Failed to set GFIR coefficients, invalid filter index %i.", gfirID);
+
+    // the chip interface takes the count as uint8_t, an unchecked size would wrap at 256
+    const std::size_t maxCoefCount = gfirID == 2 ? 120 : 40;
+    if (coefficients.size() > maxCoefCount)
+        return ReportError(OpStatus::OutOfRange,
+            "Failed to set GFIR coefficients, count %i exceeds the filter limit of %i.",
+            static_cast<int>(coefficients.size()),
+            static_cast<int>(maxCoefCount));
+
     auto& lms = mLMSChips.at(moduleIndex);
-    return lms->SetGFIRCoefficients(trx, gfirID, coefficients.data(), coefficients.size());
+    LMS7002M::ChannelScope scope(lms.get(), static_cast<uint8_t>(channel % 2));
+    return lms->SetGFIRCoefficients(trx, gfirID, coefficients.data(), static_cast<uint8_t>(coefficients.size()));
 }
 
 OpStatus LMS7002M_SDRDevice::SetGFIR(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t gfirID, bool enabled)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,8 @@ target_sources(
             streaming/TRXLooper_tests.cpp
             # parsers/CoefficientFileParserTest.cpp
             protocols/BufferInterleavingTest.cpp
-            protocols/LMS64CProtocol/ControlCommandBusyTest.cpp)
+            protocols/LMS64CProtocol/ControlCommandBusyTest.cpp
+            boards/LMS7002M_SDRDevice_GFIR_tests.cpp)
 
 add_subdirectory(embedded/lms7002m)
 

--- a/tests/boards/LMS7002M_SDRDevice_GFIR_tests.cpp
+++ b/tests/boards/LMS7002M_SDRDevice_GFIR_tests.cpp
@@ -1,0 +1,108 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "boards/LMS7002M_SDRDevice.h"
+#include "comms/SPI/ISPI.h"
+#include "limesuiteng/LMS7002M.h"
+#include "limesuiteng/OpStatus.h"
+#include "limesuiteng/RFStream.h"
+
+using namespace lime;
+
+namespace {
+
+// Answers reads with zeroes and records every register write
+class RecordingSPIStub : public ISPI
+{
+  public:
+    struct Write {
+        uint16_t address;
+        uint16_t value;
+    };
+
+    OpStatus Transact(const uint32_t* MOSI, uint32_t* MISO, uint32_t count) override
+    {
+        for (uint32_t i = 0; i < count; ++i)
+        {
+            if (MOSI[i] & (1u << 31)) // msbit 1=SPI write
+                writes.push_back({ static_cast<uint16_t>((MOSI[i] >> 16) & 0x7FFF), static_cast<uint16_t>(MOSI[i] & 0xFFFF) });
+        }
+        if (MISO != nullptr)
+            std::memset(MISO, 0, count * sizeof(uint32_t));
+        return OpStatus::Success;
+    }
+
+    std::vector<Write> writes;
+};
+
+// Bare LMS7002M_SDRDevice with a single stub-backed chip
+class TestDevice : public LMS7002M_SDRDevice
+{
+  public:
+    explicit TestDevice(std::shared_ptr<ISPI> spi) { mLMSChips.push_back(std::make_unique<LMS7002M>(spi)); }
+
+    OpStatus Configure(const SDRConfig& config, uint8_t moduleIndex) override { return OpStatus::Success; }
+    OpStatus Init() override { return OpStatus::Success; }
+    double GetClockFreq(uint8_t clk_id, uint8_t channel) override { return 0.0; }
+    OpStatus SetClockFreq(uint8_t clk_id, double freq, uint8_t channel) override { return OpStatus::Success; }
+    OpStatus SetSampleRate(uint8_t moduleIndex, TRXDir trx, uint8_t channel, double sampleRate, uint8_t oversample) override
+    {
+        return OpStatus::Success;
+    }
+    std::unique_ptr<RFStream> StreamCreate(const StreamConfig& config, uint8_t moduleIndex) override { return nullptr; }
+};
+
+constexpr uint16_t MAC_ADDR = 0x0020;
+
+bool WroteMACValue(const std::vector<RecordingSPIStub::Write>& writes, uint16_t macBits)
+{
+    for (const auto& write : writes)
+    {
+        if (write.address == MAC_ADDR && (write.value & 0x3) == macBits)
+            return true;
+    }
+    return false;
+}
+
+} // namespace
+
+namespace lime::testing {
+
+TEST(LMS7002M_SDRDevice_GFIR, SetCoefficientsSelectsRequestedChannel)
+{
+    auto spi = std::make_shared<RecordingSPIStub>();
+    TestDevice device(spi);
+
+    spi->writes.clear();
+    // stub registers read back as oversample(2), which limits GFIR1 to 10 coefficients
+    const std::vector<double> coefficients(8, 0.5);
+    ASSERT_EQ(device.SetGFIRCoefficients(0, TRXDir::Rx, 1, 0, coefficients), OpStatus::Success);
+    EXPECT_TRUE(WroteMACValue(spi->writes, 0x2)) << "channel B was never selected";
+}
+
+TEST(LMS7002M_SDRDevice_GFIR, GetCoefficientsSelectsRequestedChannel)
+{
+    auto spi = std::make_shared<RecordingSPIStub>();
+    TestDevice device(spi);
+
+    spi->writes.clear();
+    device.GetGFIRCoefficients(0, TRXDir::Rx, 1, 0);
+    EXPECT_TRUE(WroteMACValue(spi->writes, 0x2)) << "channel B was never selected";
+}
+
+TEST(LMS7002M_SDRDevice_GFIR, SetCoefficientsRejectsOversizedCount)
+{
+    auto spi = std::make_shared<RecordingSPIStub>();
+    TestDevice device(spi);
+
+    // 256 used to wrap to a count of 0 and report success while writing nothing
+    EXPECT_EQ(device.SetGFIRCoefficients(0, TRXDir::Rx, 0, 0, std::vector<double>(256, 0.0)), OpStatus::OutOfRange);
+    EXPECT_EQ(device.SetGFIRCoefficients(0, TRXDir::Rx, 0, 0, std::vector<double>(41, 0.0)), OpStatus::OutOfRange);
+    EXPECT_EQ(device.SetGFIRCoefficients(0, TRXDir::Tx, 0, 2, std::vector<double>(121, 0.0)), OpStatus::OutOfRange);
+    EXPECT_EQ(device.SetGFIRCoefficients(0, TRXDir::Rx, 0, 3, std::vector<double>(10, 0.0)), OpStatus::OutOfRange);
+}
+
+} // namespace lime::testing


### PR DESCRIPTION
Fixes #224, fixes #225. GFIR coefficient get/set ignored the channel argument, so coefficients went to whichever channel MAC last pointed at. The count was also narrowed to uint8_t unchecked, so 256 coefficients wrapped to 0 and reported success writing nothing. Channel now goes through ChannelScope like the neighboring functions, count is validated against the filter limit. Regression tests on a recording SPI stub, 52/52 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)