### PR TITLE
build: align release version numbers on 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ include(CMakeDependentOption)
 # are being built from the same source, as source package can have only one version.
 project(
     "limesuiteng"
-    VERSION 25.1.0
+    VERSION 1.0.0
     DESCRIPTION "Meta project encompassing all LimeSuiteNG components"
     LANGUAGES C CXX)
 message(STATUS "cmake version: ${CMAKE_VERSION}")

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,4 +1,4 @@
-Release 0.3.0 ()
+Release 1.0.0 ()
 
 - Added RFStream interface, deprecated SDRDevice::Stream* functions
 - Split legacy LMS_API wrapper into separate 'limesuiteng-legacyapi' library

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-limesuiteng (25.1.0) UNRELEASED; urgency=low
+limesuiteng (1.0.0) UNRELEASED; urgency=low
 
   * Initial packaged release
 


### PR DESCRIPTION
Fixes #226. The suite version and changelogs disagreed (25.1.0 / 0.3.0 / undated entry). Top-level project, source package changelog and Changelog.txt now say 1.0.0. The library soversion intentionally stays at 0.3: it is an ABI generation number, to be bumped together with the abidiff baseline when v1.0.0-rc1 is tagged (#190). limepcie-dkms keeps its independent versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)