### PR TITLE
legacyapi: don't cache the LPF bandwidth when setting it failed

### DIFF
--- a/src/legacyapi/LMS_APIWrapper.cpp
+++ b/src/legacyapi/LMS_APIWrapper.cpp
@@ -492,9 +492,9 @@ API_EXPORT int CALL_CONV LMS_SetLPFBW(lms_device_t* device, bool dir_tx, size_t 
 
     const lime::TRXDir direction = DirFromBool(dir_tx);
     const OpStatus status = apiDevice->device->SetLowPassFilter(apiDevice->moduleIndex, direction, chan, bandwidth);
-    apiDevice->lastSavedLPFValue[chan][dir_tx] = bandwidth;
+    if (status == OpStatus::Success)
+        apiDevice->lastSavedLPFValue[chan][dir_tx] = bandwidth;
     return OpStatusToReturnCode(status);
-    return 0;
 }
 
 API_EXPORT int CALL_CONV LMS_GetLPFBWRange(lms_device_t* device, bool dir_tx, lms_range_t* range)


### PR DESCRIPTION
Fixes #227. LMS_SetLPFBW stored the requested bandwidth even when SetLowPassFilter rejected it, and LMS_SetLPF(enable) re-applies that cached value, so one failed call poisoned later enables. The cache is now updated only on success. Also drops an unreachable return left in the function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)