### PR TITLE
docs: add the device setup flow diagram

### DIFF
--- a/docs/developer/Introduction/device_setup_flow.dox
+++ b/docs/developer/Introduction/device_setup_flow.dox
@@ -1,0 +1,34 @@
+/**
+ * @page device_setup_flow_page Device setup flow
+ *
+ * @if RST_SUPPORT
+ * @embedRstVerbatim{
+ * .. mermaid:: device_setup_flow.mmd
+ * }
+ * @endif
+ *
+ * @section device_setup_flow_summary Summary
+ *
+ * Device setup flowchart shows the typical sequence an application goes through to bring a device
+ * from discovery to sample streaming and back down again.
+ *
+ * Devices are discovered with ``DeviceRegistry::enumerate()``, which returns a handle for each
+ * device found. A handle is turned into a usable ``SDRDevice`` instance with
+ * ``DeviceRegistry::makeDevice()``. After an optional ``SetMessageLogCallback()`` to receive log
+ * messages, ``Init()`` brings the chip into a known operational state.
+ *
+ * ``Configure()`` applies an ``SDRConfig`` structure in one call: it enables the requested
+ * channels, tunes the LO frequency, sets the sample rate, selects the antenna path, configures
+ * filters, and runs calibration where requested. Configuration is applied per RF chip, selected
+ * with the module index.
+ *
+ * Sample streaming is handled by an ``RFStream`` object created with ``StreamCreate()`` from a
+ * ``StreamConfig`` structure that lists the channels and the sample format. After ``Start()`` the
+ * application exchanges samples with ``StreamRx()`` / ``StreamTx()`` calls. ``Stop()`` halts the
+ * stream; the stream object must be released before the device itself is freed with
+ * ``DeviceRegistry::freeDevice()``.
+ *
+ * The ``basicRX`` and ``basicTX`` programs in the source tree ``src/examples`` directory follow
+ * exactly this sequence and can be used as a starting point.
+ *
+ */

--- a/docs/developer/Introduction/device_setup_flow.mmd
+++ b/docs/developer/Introduction/device_setup_flow.mmd
@@ -1,0 +1,22 @@
+sequenceDiagram
+    participant App as Application
+    participant Reg as DeviceRegistry
+    participant Dev as SDRDevice
+    participant Stream as RFStream
+
+    App->>Reg: enumerate()
+    Reg-->>App: DeviceHandle list
+    App->>Reg: makeDevice(handle)
+    Reg-->>App: SDRDevice
+    App->>Dev: SetMessageLogCallback(callback)
+    App->>Dev: Init()
+    App->>Dev: Configure(SDRConfig, moduleIndex)
+    Note over Dev: enables channels, tunes LO,<br/>sets sample rate, antenna path,<br/>filters and calibration
+    App->>Dev: StreamCreate(StreamConfig, moduleIndex)
+    Dev-->>App: RFStream
+    App->>Stream: Start()
+    loop Sample exchange
+        App->>Stream: StreamRx() / StreamTx()
+    end
+    App->>Stream: Stop()
+    App->>Reg: freeDevice(device)

--- a/docs/developer/Introduction/index.dox
+++ b/docs/developer/Introduction/index.dox
@@ -13,6 +13,7 @@
  * - @subpage dev_reg_class_diag_page
  * - @subpage device_class_diag_page
  * - @subpage streaming_class_diag_page
+ * - @subpage device_setup_flow_page
  * 
  * 
  * 

--- a/docs/developer/Introduction/index.rst
+++ b/docs/developer/Introduction/index.rst
@@ -8,6 +8,7 @@ Introduction
    device_reg_class.rst
    device_class.rst
    streaming_class.rst
+   device_setup_flow.rst
 
 .. doxygenpage:: diagrams_intro
    :content-only:


### PR DESCRIPTION
Flow part of #183, class diagram updates are in #221. Adds a mermaid sequence diagram of the device lifecycle (enumerate through freeDevice) mirroring the basicRX/basicTX examples, with the page text explaining each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)