### PR TITLE
packaging: produce Windows zip and NSIS installer in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -86,6 +86,17 @@ jobs:
           name: limesuiteng-windows-${{matrix.arch}}
           path: ${{github.workspace}}/artifact
 
+      - name: Package zip and installer
+        run: cpack -C ${{env.BUILD_TYPE}} --config ${{github.workspace}}/build/packages/CPackConfig.cmake
+
+      - name: Upload Windows packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: limesuiteng-windows-packages-${{matrix.arch}}
+          path: |
+            ${{github.workspace}}/build/packages/*.zip
+            ${{github.workspace}}/build/packages/*.exe
+
   build-MacOS:
     name: MacOS build
     runs-on: macos-latest

--- a/packages/CPackProperties.cmake
+++ b/packages/CPackProperties.cmake
@@ -59,4 +59,7 @@ if(WIN32)
     # offer adding the install directory to PATH, so the CLI tools work from any terminal
     set(CPACK_NSIS_MODIFY_PATH ON)
     set(CPACK_PACKAGE_EXECUTABLES "limeGUI" "Lime Suite NG GUI")
+
+    # bundle the MSVC C++ runtime redistributable DLLs into bin/
+    include(InstallRequiredSystemLibraries)
 endif()

--- a/packages/CPackProperties.cmake
+++ b/packages/CPackProperties.cmake
@@ -39,3 +39,24 @@ set(CPACK_PACKAGE_RELOCATABLE "true")
 set(CPACK_PACKAGE_CONTACT "Lime Microsystems <info@limemicro.com>")
 set(CPACK_PACKAGE_VENDOR "Humanity")
 set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SOURCE_DIR}/COPYING)
+
+if(WIN32)
+    # Windows gets a zip and an NSIS installer (#149), Linux keeps distro packaging
+    set(CPACK_GENERATOR "ZIP;NSIS")
+
+    if(CMAKE_GENERATOR_PLATFORM)
+        set(WINDOWS_PACKAGE_ARCH ${CMAKE_GENERATOR_PLATFORM})
+    else()
+        set(WINDOWS_PACKAGE_ARCH ${CMAKE_SYSTEM_PROCESSOR})
+    endif()
+    set(CPACK_PACKAGE_FILE_NAME "limesuiteng-${PROJECT_VERSION}-windows-${WINDOWS_PACKAGE_ARCH}")
+
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "LimeSuiteNG")
+    set(CPACK_NSIS_PACKAGE_NAME "Lime Suite NG")
+    set(CPACK_NSIS_DISPLAY_NAME "Lime Suite NG ${PROJECT_VERSION}")
+    set(CPACK_NSIS_URL_INFO_ABOUT "https://myriadrf.org/projects/limesdr/")
+    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+    # offer adding the install directory to PATH, so the CLI tools work from any terminal
+    set(CPACK_NSIS_MODIFY_PATH ON)
+    set(CPACK_PACKAGE_EXECUTABLES "limeGUI" "Lime Suite NG GUI")
+endif()


### PR DESCRIPTION
Part of #149. CI already uploads raw Windows binaries (#217); this adds a versioned zip and an NSIS installer built by CPack and uploaded as artifacts for x64 and Win32: component chooser, optional PATH entry for the CLI tools, start menu shortcut for limeGUI, uninstall before reinstall. Publishing them as release assets can follow once v1.0.0-rc1 is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)