### PR TITLE
legacyapi: report GFIR coefficient read failures

### DIFF
--- a/src/boards/LMS7002M_SDRDevice.cpp
+++ b/src/boards/LMS7002M_SDRDevice.cpp
@@ -932,7 +932,9 @@ std::vector<double> LMS7002M_SDRDevice::GetGFIRCoefficients(uint8_t moduleIndex,
     const uint8_t count = gfirID == 2 ? 120 : 40;
     std::vector<double> coefficientBuffer(count);
 
-    lms->GetGFIRCoefficients(trx, gfirID, coefficientBuffer.data(), count);
+    // the signature has no status channel, an empty vector signals failure
+    if (lms->GetGFIRCoefficients(trx, gfirID, coefficientBuffer.data(), count) != OpStatus::Success)
+        return {};
 
     return coefficientBuffer;
 }

--- a/src/legacyapi/LMS_APIWrapper.cpp
+++ b/src/legacyapi/LMS_APIWrapper.cpp
@@ -1389,6 +1389,10 @@ API_EXPORT int CALL_CONV LMS_GetGFIRCoeff(lms_device_t* device, bool dir_tx, siz
     auto coefficients = apiDevice->device->GetGFIRCoefficients(
         apiDevice->moduleIndex, dir_tx ? lime::TRXDir::Tx : lime::TRXDir::Rx, chan, static_cast<uint8_t>(filt));
 
+    // empty means the read failed, previously this still reported success
+    if (coefficients.empty())
+        return -1;
+
     for (std::size_t i = 0; i < count && i < coefficients.size(); ++i)
         coef[i] = coefficients.at(i);
 

--- a/tests/boards/LMS7002M_SDRDevice_GFIR_tests.cpp
+++ b/tests/boards/LMS7002M_SDRDevice_GFIR_tests.cpp
@@ -105,4 +105,13 @@ TEST(LMS7002M_SDRDevice_GFIR, SetCoefficientsRejectsOversizedCount)
     EXPECT_EQ(device.SetGFIRCoefficients(0, TRXDir::Rx, 0, 3, std::vector<double>(10, 0.0)), OpStatus::OutOfRange);
 }
 
+TEST(LMS7002M_SDRDevice_GFIR, GetCoefficientsReportsFailure)
+{
+    auto spi = std::make_shared<RecordingSPIStub>();
+    TestDevice device(spi);
+
+    // an invalid filter index used to return a zero-filled buffer as success
+    EXPECT_TRUE(device.GetGFIRCoefficients(0, TRXDir::Rx, 0, 3).empty());
+}
+
 } // namespace lime::testing


### PR DESCRIPTION
Fixes #236. The device method now returns an empty vector on failure, its only signal without changing the signature, and the legacy wrapper turns that into -1. Regression test included. Found while writing a dead-bus test which surfaced #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)