### PR TITLE
ci: build arm64 debian packages

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -22,7 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+        # arm variants run on the free GitHub arm64 runners
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm]
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +45,7 @@ jobs:
 
       # dh-dkms was split into separate package
       - name: Install dh-dkms
-        if: ${{ matrix.os == 'ubuntu-24.04'}}
+        if: ${{ startsWith(matrix.os, 'ubuntu-24.04') }}
         run: |
           sudo apt-get install dh-dkms
 
@@ -69,7 +70,7 @@ jobs:
       - name: Archive packaging artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.ubuntu_codename }}
+          name: ${{ env.ubuntu_codename }}-${{ runner.arch }}
           retention-days: 2
           path: |
             ${{github.workspace}}/*.tar.xz


### PR DESCRIPTION
Part of #191. The packaging job only produced amd64 debs, the matrix now includes the free GitHub arm64 runners for jammy and noble, artifact names carry the architecture. Publishing to repo.myriadrf.org stays manual until server credentials are wired up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)