### PR TITLE
liblimesuiteng: bump to 1.0.0 for the rc1 tag

### DIFF
--- a/debian/liblimesuiteng.changelog
+++ b/debian/liblimesuiteng.changelog
@@ -1,4 +1,4 @@
-limesuiteng (0.3.0) UNRELEASED; urgency=low
+limesuiteng (1.0.0) UNRELEASED; urgency=low
 
   * Initial Release
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FeatureSummary)
 include(CMakeDependentOption)
 project(
     "liblimesuiteng"
-    VERSION 0.3.0
+    VERSION 1.0.0
     DESCRIPTION "Core library for interacting with LimeSDR based devices"
     LANGUAGES C CXX)
 checkdebianchangelogversion(${PROJECT_NAME})


### PR DESCRIPTION
Part of #190, DRAFT until tagging day. Semantic versioning applies to the library, the suite stays calendar versioned. Soname moves to 1.0-1, so this merges together with the v1.0.0-rc1 tagging and the abidiff baseline switch. The ABI check on this PR is expected to flag the soname transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)