### PR TITLE
cli: fix out-of-bounds write when reading input files

### DIFF
--- a/cli/limeCSR.cpp
+++ b/cli/limeCSR.cpp
@@ -95,14 +95,15 @@ static std::string ReadFile(const std::string& fileName)
         exit(EXIT_FAILURE);
     }
     inputFile.seekg(0, std::ios::end);
-    long fileSize = inputFile.tellg();
+    const std::streamoff fileSize = inputFile.tellg();
     inputFile.seekg(0, std::ios::beg);
 
+    if (fileSize <= 0)
+        return {};
+
     buffer.resize(fileSize);
-    inputFile.read(&buffer[0], fileSize);
-    inputFile.close();
-    buffer[fileSize] = 0;
-    return buffer.data();
+    inputFile.read(buffer.data(), fileSize);
+    return std::string(buffer.begin(), buffer.end());
 }
 
 int main(int argc, char** argv)

--- a/cli/limeSPI.cpp
+++ b/cli/limeSPI.cpp
@@ -116,14 +116,15 @@ static std::string ReadFile(const std::string& fileName)
         exit(EXIT_FAILURE);
     }
     inputFile.seekg(0, std::ios::end);
-    long fileSize = inputFile.tellg();
+    const std::streamoff fileSize = inputFile.tellg();
     inputFile.seekg(0, std::ios::beg);
 
+    if (fileSize <= 0)
+        return {};
+
     buffer.resize(fileSize);
-    inputFile.read(&buffer[0], fileSize);
-    inputFile.close();
-    buffer[fileSize] = 0;
-    return buffer.data();
+    inputFile.read(buffer.data(), fileSize);
+    return std::string(buffer.begin(), buffer.end());
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Fixes #245. The string is built directly from the bytes read; empty or unreadable files return an empty string. Verified with ASan/UBSan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)