### PR TITLE
comms: fix USB open null deref, PCIe errno handling, VID/PID ordering

### DIFF
--- a/src/comms/PCIe/LimePCIe.cpp
+++ b/src/comms/PCIe/LimePCIe.cpp
@@ -82,32 +82,31 @@ OpStatus LimePCIe::RunControlCommand(uint8_t* request, uint8_t* response, size_t
 
     int ret = ioctl(mFileDescriptor, LIMEPCIE_IOCTL_RUN_CONTROL_COMMAND, &pkt);
 
-    switch (ret)
+    // ioctl reports failure as -1 with errno set, switching on the return value
+    // left the errno cases below unreachable
+    if (ret < 0)
     {
-    case 0:
-        break;
-    case ENOTTY:
-    case -ENOTTY:
-    case ENOIOCTLCMD:
-    case -ENOIOCTLCMD: {
-        // driver does not support ioctl, fallback to write/read
-        ret = WriteControl(request, length, timeout_ms);
-        if (static_cast<size_t>(ret) != length)
-            return OpStatus::IOFailure;
+        switch (errno)
+        {
+        case ENOTTY:
+        case ENOIOCTLCMD: {
+            // driver does not support ioctl, fallback to write/read
+            ret = WriteControl(request, length, timeout_ms);
+            if (static_cast<size_t>(ret) != length)
+                return OpStatus::IOFailure;
 
-        ret = ReadControl(response, length, timeout_ms);
-        if (static_cast<size_t>(ret) != length)
+            ret = ReadControl(response, length, timeout_ms);
+            if (static_cast<size_t>(ret) != length)
+                return OpStatus::IOFailure;
+            return OpStatus::Success;
+        }
+        case EBUSY:
+            return OpStatus::Busy;
+        case ETIMEDOUT:
+            return OpStatus::Timeout;
+        default:
             return OpStatus::IOFailure;
-        return OpStatus::Success;
-    }
-    case EBUSY:
-    case -EBUSY:
-        return OpStatus::Busy;
-    case ETIMEDOUT:
-    case -ETIMEDOUT:
-        return OpStatus::Timeout;
-    default:
-        return OpStatus::IOFailure;
+        }
     }
 
     if (pkt.length != length)

--- a/src/comms/USB/IUSB.h
+++ b/src/comms/USB/IUSB.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <tuple>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -40,7 +41,10 @@ class IUSB
         /// @brief The comparison operator (needed for use in std::set)
         /// @param rhs The other VID/PID pair to compare to.
         /// @return True if this element is "smaller" than the other one.
-        bool operator<(const VendorProductId& rhs) const { return vendorId < rhs.vendorId || productId < rhs.productId; }
+        bool operator<(const VendorProductId& rhs) const
+        {
+            return std::tie(vendorId, productId) < std::tie(rhs.vendorId, rhs.productId);
+        }
     };
     /**
      * @brief Returns list of detected devices descriptors used for connecting to device.

--- a/src/comms/USB/UnixUsb.cpp
+++ b/src/comms/USB/UnixUsb.cpp
@@ -278,6 +278,14 @@ bool UnixUsb::Connect(uint16_t vid, uint16_t pid, const char* serial)
             continue;
         }
 
+        // on any open failure dev_handle is left null, skip this device instead
+        // of dereferencing it below
+        if (openStatus != LIBUSB_SUCCESS)
+        {
+            dev_handle = nullptr;
+            continue;
+        }
+
         std::string foundSerial;
         if (desc.iSerialNumber > 0)
         {


### PR DESCRIPTION
Fixes #246. Any open failure now skips the device, errno is inspected like elsewhere in the file, and the comparator uses std::tie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)