### PR TITLE
gui: fix out-of-bounds marker index bugs in the FFT graph

### DIFF
--- a/GUI/oglGraph/OpenGLGraph.cpp
+++ b/GUI/oglGraph/OpenGLGraph.cpp
@@ -1205,7 +1205,7 @@ int OpenGLGraph::AddMarker(int posX)
         mark->show = true;
         mark->posX = series[0]->values[mark->dataValueIndex].x;
         mark->posY = series[0]->values[mark->dataValueIndex].y;
-        mark->color = mMarkerColors[markers.size()];
+        mark->color = mMarkerColors[mark->id];
         return mark->id;
     }
     return -1;
@@ -1232,8 +1232,8 @@ int OpenGLGraph::AddMarkerAtValue(float xValue)
             return -1;
         mark->posX = xValue;
 
-        //find closest data point index
-        for (std::size_t i = 0; i < series[0]->values.size(); ++i)
+        //find closest data point index, start at 1 so values[i - 1] stays in bounds
+        for (std::size_t i = 1; i < series[0]->values.size(); ++i)
         {
             if (series[0]->values[i].x >= mark->posX)
             {
@@ -1258,7 +1258,7 @@ int OpenGLGraph::AddMarkerAtValue(float xValue)
         mark->used = true;
         mark->posX = series[0]->values[mark->dataValueIndex].x;
         mark->posY = series[0]->values[mark->dataValueIndex].y;
-        mark->color = mMarkerColors[markers.size()];
+        mark->color = mMarkerColors[mark->id];
         mMarkersDlg->refreshMarkFreq = true;
         return mark->id;
     }
@@ -1462,7 +1462,7 @@ void OpenGLGraph::MoveMarker(int markerID, int posX)
             }
             else
             {
-                markers[markerID].dataValueIndex = i - 2;
+                markers[markerID].dataValueIndex = i - 1;
             }
             break;
         }
@@ -1484,7 +1484,7 @@ void OpenGLGraph::MoveMarker(int markerID, int posX)
             }
             else
             {
-                markers[markerID].dataValueIndex = i - 2;
+                markers[markerID].dataValueIndex = i - 1;
             }
             break;
         }

--- a/GUI/oglGraph/dlgMarkers.cpp
+++ b/GUI/oglGraph/dlgMarkers.cpp
@@ -178,15 +178,18 @@ void dlgMarkers::UpdateValues()
         double valueB = 0;
         int cnt = 0;
 
-        if (!parent_graph->series[0]->values.empty() && parent_graph->series[0]->visible)
+        const std::size_t valueIndex = parent_graph->markers[i].dataValueIndex;
+
+        // the marker index can outlive a series resize (e.g. smaller FFT), guard the .at()
+        if (valueIndex < parent_graph->series[0]->values.size() && parent_graph->series[0]->visible)
         {
-            valueA = parent_graph->series[0]->values.at(parent_graph->markers[i].dataValueIndex).y;
+            valueA = parent_graph->series[0]->values.at(valueIndex).y;
             cnt = std::snprintf(text, sizeof(text), "%3.1f (ChA) ; ", valueA);
         }
 
-        if (!parent_graph->series[1]->values.empty() && parent_graph->series[1]->visible)
+        if (valueIndex < parent_graph->series[1]->values.size() && parent_graph->series[1]->visible)
         {
-            valueB = parent_graph->series[1]->values.at(parent_graph->markers[i].dataValueIndex).y;
+            valueB = parent_graph->series[1]->values.at(valueIndex).y;
             std::snprintf(text + cnt, std::max<int>(sizeof(text) - cnt, 0), "%3.1f (ChB) ;", valueB);
         }
 


### PR DESCRIPTION
Fixes #247. Loop starts at i=1, the neighbour index is i-1, colours are indexed by the marker slot, and the stale-index access is bounds-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)