### PR TITLE
limepcie: fix divide-by-zero, DMA leak, and console build errors

### DIFF
--- a/drivers/linux/limepcie/limepcie_core.c
+++ b/drivers/linux/limepcie/limepcie_core.c
@@ -182,6 +182,8 @@ static void limepcie_dma_buffer_free(struct limepcie_dma *dma, void *va_memory, 
         kfree(va_memory);
 }
 
+static void limepcie_dma_destroy(struct limepcie_dma *dma);
+
 // Initializes a single direction data transfer controls
 static int limepcie_dma_init(
     struct limepcie_dma *dma, uint8_t moduleIndex, enum dma_data_direction direction, uint32_t bufferSize, uint16_t bufferCount)
@@ -246,6 +248,9 @@ static int limepcie_dma_init(
         if (!memoryBuffer)
         {
             dev_err(sysDev, "Failed to allocate dma buffer\n");
+            // free the buffers allocated so far, the caller does not clean up a
+            // channel whose init failed
+            limepcie_dma_destroy(dma);
             return -ENOMEM;
         }
 #ifdef DEBUG_MEM
@@ -733,6 +738,14 @@ static long limepcie_ioctl_trx(struct file *file, unsigned int cmd, unsigned lon
         if (m.control.enabled && dma->enabled)
         {
             ret = -EBUSY;
+            break;
+        }
+
+        // irqPeriod is used as a modulo divisor when scheduling interrupts,
+        // reject zero from userspace before it causes a divide-by-zero oops
+        if (m.control.enabled && m.irqPeriod == 0)
+        {
+            ret = -EINVAL;
             break;
         }
 

--- a/drivers/linux/limepcie/limeuart.c
+++ b/drivers/linux/limepcie/limeuart.c
@@ -482,13 +482,15 @@ static struct platform_driver limeuart_platform_driver = {
 
 static void limeuart_console_write(struct console *co, const char *s, unsigned int count)
 {
-    dev_dbg(port->dev, "%s\n", __func__);
     struct limeuart_port *uart;
     struct uart_port *port;
     unsigned long flags;
 
     uart = (struct limeuart_port *)xa_load(&limeuart_array, co->index);
+    if (!uart)
+        return;
     port = &uart->port;
+    dev_dbg(port->dev, "%s\n", __func__);
 
     spin_lock_irqsave(&port->lock, flags);
     uart_console_write(port, s, count, limeuart_putchar);
@@ -497,7 +499,6 @@ static void limeuart_console_write(struct console *co, const char *s, unsigned i
 
 static int limeuart_console_setup(struct console *co, char *options)
 {
-    dev_dbg(port->dev, "%s\n", __func__);
     struct limeuart_port *uart;
     struct uart_port *port;
     int baud = 115200;
@@ -510,6 +511,7 @@ static int limeuart_console_setup(struct console *co, char *options)
         return -ENODEV;
 
     port = &uart->port;
+    dev_dbg(port->dev, "%s\n", __func__);
     if (!port->membase)
         return -ENODEV;
 


### PR DESCRIPTION
Fixes #248. irqPeriod=0 is rejected with -EINVAL, dma_init frees its partial buffers on failure, and the console functions declare port before use with a NULL check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)