### PR TITLE
embedded, gui: fix NCO shift UB, calibration restore, CDCM6208 parse crash

### DIFF
--- a/GUI/chips/CDCM6208/CDCM6208_wxgui.cpp
+++ b/GUI/chips/CDCM6208/CDCM6208_wxgui.cpp
@@ -876,8 +876,10 @@ void CDCM6208_panelgui::OnChange(wxCommandEvent& event)
             i_val = std::stoi(str);
             CDCM->SetSPIBaseAddr(i_val);
         }
-    } catch (std::invalid_argument& e)
+    } catch (const std::logic_error& e)
     {
+        // std::logic_error covers both invalid_argument and out_of_range from
+        // stoi/stod, an overflowing value no longer crashes the application
         return;
     }
 

--- a/embedded/lms7002m/calibrations.c
+++ b/embedded/lms7002m/calibrations.c
@@ -936,7 +936,7 @@ static lime_Result lms7002m_calibrate_tx_setup(lms7002m_context* self, uint32_t 
         status = lms7002m_set_frequency_sx(self, false, SXRfreq);
         if (status != lime_Result_Success)
         {
-            lms7002m_spi_read(self, x0020val); //restore used channel
+            lms7002m_spi_write(self, 0x0020, x0020val); //restore used channel
             return status;
         }
     }

--- a/embedded/lms7002m/lms7002m.c
+++ b/embedded/lms7002m/lms7002m.c
@@ -1246,7 +1246,9 @@ uint32_t lms7002m_get_nco_frequency(lms7002m_context* self, bool isTx, const uin
     const uint32_t refClk_Hz = lms7002m_get_reference_clock_tsp(self, isTx);
     const uint16_t addr = isTx ? 0x0240 : 0x0440;
     uint32_t fcw = 0;
-    fcw |= lms7002m_spi_read(self, addr + 2 + index * 2) << 16; //NCO frequency control word register MSB part.
+    // cast before the shift, a uint16_t promotes to signed int and << 16 of a
+    // value >= 0x8000 would be signed overflow
+    fcw |= (uint32_t)lms7002m_spi_read(self, addr + 2 + index * 2) << 16; //NCO frequency control word register MSB part.
     fcw |= lms7002m_spi_read(self, addr + 3 + index * 2); //NCO frequency control word register LSB part.
 
     return nco_fcw_to_freq(fcw, refClk_Hz);


### PR DESCRIPTION
Fixes #249. The NCO word is cast before the shift, the calibration path writes 0x0020 back, and the CDCM6208 handler catches std::logic_error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)