### PR TITLE
streaming: fix Tx packetsToBatch clamp truncated through uint8_t

### DIFF
--- a/src/streaming/TRXLooper.cpp
+++ b/src/streaming/TRXLooper.cpp
@@ -1101,7 +1101,7 @@ OpStatus TRXLooper::TxSetup()
     const auto dmaChunks{ mTxArgs.dma->GetBuffers() };
     const auto dmaBufferSize = dmaChunks.front().size;
 
-    mTx.packetsToBatch = std::clamp<uint8_t>(mTx.packetsToBatch, 1, dmaBufferSize / packetSize);
+    mTx.packetsToBatch = std::clamp<uint32_t>(mTx.packetsToBatch, 1u, dmaBufferSize / packetSize);
 
     std::vector<uint8_t*> dmaBuffers(dmaChunks.size());
     for (uint32_t i = 0; i < dmaChunks.size(); ++i)


### PR DESCRIPTION
Fixes #257. Use std::clamp<uint32_t> to match the Rx path so the value and the upper bound stay 32-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)