### PR TITLE
FPGA: honor 4096-byte packet cap in GetPacketSizeForBusSize

### DIFF
--- a/src/FPGA/FPGA_common.cpp
+++ b/src/FPGA/FPGA_common.cpp
@@ -86,7 +86,7 @@ uint32_t GetPacketSizeForBusSize(uint32_t requestSamplesCount, uint32_t sampleSi
     const uint32_t maxPacketSize = 4096;
     uint32_t samplesCount = std::min((maxPacketSize - headerSize) / frameSize, requestSamplesCount);
 
-    uint32_t packetSize = headerSize + requestSamplesCount * frameSize;
+    uint32_t packetSize = headerSize + samplesCount * frameSize;
     // reduce samples count until the whole packet is multiple of bus width
     while (packetSize % busWidth && packetSize > 0)
     {


### PR DESCRIPTION
Fixes #259. Compute packetSize from the clamped samplesCount that the trim loop already decrements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)