### PR TITLE
legacyapi: fix null dereference in LMS_GetClockFreq

### DIFF
--- a/src/legacyapi/LMS_APIWrapper.cpp
+++ b/src/legacyapi/LMS_APIWrapper.cpp
@@ -1163,9 +1163,10 @@ API_EXPORT int CALL_CONV LMS_GetClockFreq(lms_device_t* device, size_t clk_id, f
         return -1;
     }
 
+    const double clockFreq = apiDevice->device->GetClockFreq(clk_id, apiDevice->moduleIndex * 2);
     if (freq)
-        *freq = apiDevice->device->GetClockFreq(clk_id, apiDevice->moduleIndex * 2);
-    return *freq > 0 ? 0 : -1;
+        *freq = clockFreq;
+    return clockFreq > 0 ? 0 : -1;
 }
 
 API_EXPORT int CALL_CONV LMS_SetClockFreq(lms_device_t* device, size_t clk_id, float_type freq)


### PR DESCRIPTION
Fixes #260. Capture the value in a local, write it out only when freq is non-null, and base the return code on the local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)