### PR TITLE
gr-limesuiteng: null-check device before SetMessageLogCallback

### DIFF
--- a/plugins/gr-limesuiteng/lib/sdrdevice_manager.cc
+++ b/plugins/gr-limesuiteng/lib/sdrdevice_manager.cc
@@ -167,13 +167,13 @@ sdrdevice_manager::GetDeviceContextByHandle(const std::string& deviceHandleHint)
     ctx->handle = handle;
     ctx->device = std::unique_ptr<SDRDevice>(DeviceRegistry::makeDevice(handle));
 
-    ctx->device->SetMessageLogCallback(gr_loghandler_string);
-
     if (!ctx->device) {
         m_contexts.pop_back();
         logger->error(fmt::format("Unable to use device: \"{:s}\"", handle.Serialize()));
         return nullptr;
     }
+
+    ctx->device->SetMessageLogCallback(gr_loghandler_string);
     return ctx;
 }
 


### PR DESCRIPTION
Fixes #261. Move the null check ahead of the callback registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)