### PR TITLE
legacyapi: report dropped packets from the right counter in LMS_GetStreamStatus

### DIFF
--- a/src/legacyapi/LMS_APIWrapper.cpp
+++ b/src/legacyapi/LMS_APIWrapper.cpp
@@ -1018,7 +1018,7 @@ API_EXPORT int CALL_CONV LMS_GetStreamStatus(lms_stream_t* stream, lms_stream_st
     handle->parent->statsDeltas.overrun.checkpoint();
 
     handle->parent->statsDeltas.droppedPackets.set(stats.loss);
-    status->droppedPackets = handle->parent->statsDeltas.underrun.delta();
+    status->droppedPackets = handle->parent->statsDeltas.droppedPackets.delta();
     handle->parent->statsDeltas.droppedPackets.checkpoint();
 
     // status->sampleRate; // Is noted as unused


### PR DESCRIPTION
Fixes #268. Use the droppedPackets delta instead of the underrun delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)