### PR TITLE
legacyapi: don't dereference val before its null check in LMS_ReadCustomBoardParam

### DIFF
--- a/src/legacyapi/LMS_APIWrapper.cpp
+++ b/src/legacyapi/LMS_APIWrapper.cpp
@@ -1084,7 +1084,7 @@ API_EXPORT int CALL_CONV LMS_ReadCustomBoardParam(lms_device_t* device, uint8_t 
         return -1;
     }
 
-    std::vector<lime::CustomParameterIO> parameter{ { param_id, *val, units } };
+    std::vector<lime::CustomParameterIO> parameter{ { param_id, 0, units } };
     OpStatus returnValue = apiDevice->device->CustomParameterRead(parameter);
 
     if (returnValue != OpStatus::Success)


### PR DESCRIPTION
Fixes #269. Seed the query with 0; the input value is unused for a read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)