### PR TITLE
docs: fix 1 broken link(s) via archive.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Plugins for external software:
 ## Supported devices
 * [LimeSDR-USB](https://wiki.myriadrf.org/LimeSDR-USB)
 * [LimeSDR Mini](https://wiki.myriadrf.org/LimeSDR-Mini)
-* [LimeSDR Mini v2](https://limesdr-mini.myriadrf.org/index.html)
+* [LimeSDR Mini v2](http://web.archive.org/web/20260224214255/https://limesdr-mini.myriadrf.org/index.html)
 * [LimeSDR XTRX](https://limesdr-xtrx.myriadrf.org/)
 
 ## Installing


### PR DESCRIPTION
Fixes 1 broken outbound link(s) in docs using archived snapshots (Wayback).

**LinkMedic** · confidence `0.66`

- `README.md`: https://limesdr-mini.myriadrf.org/index.html… → archive

Related to #276