### PR TITLE
limepcie: bail out of probe when configure_pci fails

### DIFF
--- a/drivers/linux/limepcie/limepcie_core.c
+++ b/drivers/linux/limepcie/limepcie_core.c
@@ -1390,6 +1390,8 @@ static int limepcie_device_init(struct limepcie_device *myDevice, struct pci_dev
     myDevice->pciContext = pciContext;
     pci_set_drvdata(pciContext, myDevice);
     int ret = limepcie_configure_pci(myDevice);
+    if (ret)
+        return ret;
 
     /* Reset LimePCIe core */
 #ifdef CSR_CTRL_RESET_ADDR


### PR DESCRIPTION
Fixes #308. `limepcie_device_init()` ignored the return value of `limepcie_configure_pci()`, so a failed configure (device enable, wrong PCI revision, non-memory BAR0, or iomap failure) left `bar0_addr` NULL and execution fell straight into the reset `writel` and `TestCSR()`, dereferencing a NULL base and oopsing during probe. Return early on failure so probe backs out cleanly, matching the `IdentifyDevice()` check just below.

This is a kernel driver so I couldn't exercise it locally, but the guard mirrors the existing error handling in the same function.
