### PR TITLE
limeTRX: validate --mimo channel count against the fixed array size

### DIFF
--- a/cli/limeTRX.cpp
+++ b/cli/limeTRX.cpp
@@ -408,6 +408,11 @@ int main(int argc, char** argv)
     const uint64_t samplesToCollect = args::get(samplesCountFlag);
     const int64_t workTime = args::get(timeFlag);
     const int channelCount = mimoFlag ? args::get(mimoFlag) : 1;
+    if (channelCount < 1 || channelCount > 16) // fixed-size sample arrays below hold up to 16 channels
+    {
+        cerr << "Invalid --mimo channel count "sv << channelCount << " (must be 1..16)."sv << endl;
+        return EXIT_FAILURE;
+    }
     const bool repeater = repeaterFlag;
     const int64_t repeaterDelay = args::get(repeaterFlag);
     const bool syncPPS = syncPPSFlag;


### PR DESCRIPTION
Fixes #303.

`channelCount` came straight from `--mimo` with no upper bound, while the Tx/Rx sample pointer and vector arrays are fixed at 16 elements and indexed up to `channelCount` — so `--mimo 17` overran those stack arrays. This rejects anything outside 1..16 right after parsing. Verified `--mimo 17` and `--mimo 0` are now refused before any array use.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)