### PR TITLE
LimePlugin: apply directional settings to channel 0 as well

### DIFF
--- a/src/API/LimePlugin.cpp
+++ b/src/API/LimePlugin.cpp
@@ -689,7 +689,7 @@ static OpStatus TransferDeviceDirectionalSettings(
     }
 
     // copy setting to all channels
-    for (int i = 1; i < 2; ++i)
+    for (int i = 0; i < 2; ++i)
     {
         if (dir == TRXDir::Tx)
             node.config.channel[i].tx = trx;


### PR DESCRIPTION
Fixes #301.

The loop was `for (int i = 1; i < 2; ++i)`, so it only wrote `channel[1]`, even though the comment says all channels. Channel 0's path selection, LO override and calibration flags parsed from the config were silently left at defaults. Start the loop at 0. Built locally.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)