### PR TITLE
limepcie: bail out if PCI configuration fails during probe

### DIFF
--- a/drivers/linux/limepcie/limepcie_core.c
+++ b/drivers/linux/limepcie/limepcie_core.c
@@ -1390,6 +1390,8 @@ static int limepcie_device_init(struct limepcie_device *myDevice, struct pci_dev
     myDevice->pciContext = pciContext;
     pci_set_drvdata(pciContext, myDevice);
     int ret = limepcie_configure_pci(myDevice);
+    if (ret)
+        return ret;
 
     /* Reset LimePCIe core */
 #ifdef CSR_CTRL_RESET_ADDR


### PR DESCRIPTION
Fixes #308.

`limepcie_device_init` ignored the return of `limepcie_configure_pci` and fell through to the reset write and `TestCSR`, which dereference `bar0_addr`. On a configure failure `bar0_addr` is NULL, so probe would oops instead of failing cleanly. Return the error immediately. (Kernel module; change is a guarded early return.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)