### PR TITLE
Batch: 8 hardware-free stability/reliability fixes

### DIFF
--- a/cli/limeTRX.cpp
+++ b/cli/limeTRX.cpp
@@ -464,6 +464,12 @@ int main(int argc, char** argv)
     if (chipIndexes.empty() && device->GetDescriptor().rfSOC.size() == 1)
         chipIndexes.push_back(0);
 
+    if (chipIndexes.empty())
+    {
+        cerr << "Device has multiple RF chips; specify --chip <index>."sv << endl;
+        return EXIT_FAILURE;
+    }
+
     int rx_require = rx ? channelCount : 0;
     int tx_require = tx ? channelCount : 0;
 

--- a/src/boards/MMX8/MM_X8.cpp
+++ b/src/boards/MMX8/MM_X8.cpp
@@ -771,7 +771,7 @@ OpStatus LimeSDR_MMX8::CustomParameterWrite(const std::vector<CustomParameterIO>
         int id = param.id & 0xFF;
 
         std::vector<CustomParameterIO> parameter{ { id, param.value, param.units } };
-        status = LMS64CProtocol::CustomParameterWrite(*controlPort, parameters, subModuleIndex);
+        status = LMS64CProtocol::CustomParameterWrite(*controlPort, parameter, subModuleIndex);
 
         if (status != OpStatus::Success)
             return status;
@@ -789,7 +789,7 @@ OpStatus LimeSDR_MMX8::CustomParameterRead(std::vector<CustomParameterIO>& param
         int id = param.id & 0xFF;
 
         std::vector<CustomParameterIO> parameter{ { id, param.value, param.units } };
-        status = LMS64CProtocol::CustomParameterRead(*controlPort, parameters, subModuleIndex);
+        status = LMS64CProtocol::CustomParameterRead(*controlPort, parameter, subModuleIndex);
 
         if (status != OpStatus::Success)
             return status;

--- a/src/chips/LMS8001/LMS8001.cpp
+++ b/src/chips/LMS8001/LMS8001.cpp
@@ -249,7 +249,9 @@ OpStatus LMS8001::SPI_read_batch(const uint16_t* spiAddr, uint16_t* spiData, uin
         dataWr[i] = spiAddr[i];
     }
 
-    controlPort->Transact(dataWr.data(), dataRd.data(), cnt);
+    OpStatus status = controlPort->Transact(dataWr.data(), dataRd.data(), cnt);
+    if (status != OpStatus::Success)
+        return status;
     for (size_t i = 0; i < cnt; ++i)
     {
         spiData[i] = dataRd[i] & 0xffff;

--- a/src/chips/LMS8001/LMS8001.cpp
+++ b/src/chips/LMS8001/LMS8001.cpp
@@ -98,6 +98,8 @@ OpStatus LMS8001::LoadConfig(const std::string& filename)
         tempSens_T0 = parser.getAs("T0", TEMPSENS_T0);
 
         auto section = parser.sections.find("lms8001_registers");
+        if (section == parser.sections.end())
+            return OpStatus::Error;
 
         for (auto pairs = section->second->begin(); pairs != section->second->end(); pairs++)
         {

--- a/src/comms/PCIe/LimePCIeDMA.cpp
+++ b/src/comms/PCIe/LimePCIeDMA.cpp
@@ -143,7 +143,7 @@ OpStatus LimePCIeDMA::EnableContinuous(bool enabled, uint32_t maxTransferSize, u
     int ret = ioctl(port->mFileDescriptor, LIMEPCIE_IOCTL_DMA_CONTROL_CONTINUOUS, &args);
     if (ret < 0)
     {
-        switch (ret)
+        switch (errno)
         {
         case EBUSY:
             return ReportError(OpStatus::Busy, "DMA is already enabled. errno(%i) %s", errno, strerror(errno));

--- a/src/comms/USB/UnixUsb.cpp
+++ b/src/comms/USB/UnixUsb.cpp
@@ -1,5 +1,6 @@
 #include "UnixUsb.h"
 
+#include <atomic>
 #include <thread>
 #include <cassert>
 #include <cinttypes>
@@ -23,7 +24,7 @@ using namespace std::literals::string_literals;
 namespace lime {
 
 static libusb_context* gContextLibUsb{ nullptr };
-static int activeUSBconnections = 0;
+static std::atomic<int> activeUSBconnections{ 0 };
 static std::thread gUSBProcessingThread; // single thread for processing USB callbacks
 
 static void HandleLibusbEvents(libusb_context* context)
@@ -42,8 +43,7 @@ static void HandleLibusbEvents(libusb_context* context)
 
 static int SessionRefCountIncrement()
 {
-    ++activeUSBconnections;
-    if (activeUSBconnections == 1)
+    if (++activeUSBconnections == 1)
     {
         int returnCode = libusb_init(&gContextLibUsb); // Initialize the library for the session we just declared
         if (returnCode < 0)
@@ -70,8 +70,7 @@ static int SessionRefCountIncrement()
 
 static int SessionRefCountDecrement()
 {
-    --activeUSBconnections;
-    if (activeUSBconnections == 0 && gUSBProcessingThread.joinable())
+    if (--activeUSBconnections == 0 && gUSBProcessingThread.joinable())
     {
         gUSBProcessingThread.join();
         libusb_exit(gContextLibUsb);

--- a/src/legacyapi/LMS_APIWrapper.cpp
+++ b/src/legacyapi/LMS_APIWrapper.cpp
@@ -752,9 +752,11 @@ API_EXPORT int CALL_CONV LMS_DestroyStream(lms_device_t* device, lms_stream_t* s
     // apiDevice->device->StreamDestroy(apiDevice->moduleIndex);
     apiDevice->stream.reset();
     SubChannelHandle* handle = reinterpret_cast<SubChannelHandle*>(stream->handle);
-    handle->stagingArea->maskChannelsSetup = ClearBit(handle->stagingArea->maskChannelsSetup, handle->channelIndex);
     if (handle != nullptr)
+    {
+        handle->stagingArea->maskChannelsSetup = ClearBit(handle->stagingArea->maskChannelsSetup, handle->channelIndex);
         delete handle;
+    }
 
     auto& channels = apiDevice->lastSavedStreamConfig.channels.at(stream->isTx ? lime::TRXDir::Tx : lime::TRXDir::Rx);
     auto iter = std::find(channels.begin(), channels.end(), stream->channel);

--- a/src/threadHelper/threadHelper.cpp
+++ b/src/threadHelper/threadHelper.cpp
@@ -96,7 +96,7 @@ int lime::SetOSCurrentThreadPriority(ThreadPriority priority, ThreadPolicy polic
         static_cast<int>(((prio_max - prio_min) / static_cast<float>(ThreadPriority::HIGHEST)) * static_cast<int>(priority)) +
         prio_min;
 
-    if (int ret = pthread_setschedparam(pthread_self(), sched_policy, &sch) != 0)
+    if (int ret = pthread_setschedparam(pthread_self(), sched_policy, &sch))
     {
         lime::debug("SetOSCurrentThreadPriority: Failed to set priority(%d), sched_prio(%d), policy(%d), ret(%d)",
             static_cast<int>(priority),


### PR DESCRIPTION
Groups 8 small, independent stability/reliability fixes into one PR to keep CI usage down (as suggested — one CI run for the PR instead of one per fix). Each fix is its own commit; the full project builds locally.

- Fixes #278 — LMS8001: check the config section exists before dereferencing it (no more UB on a file missing `[lms8001_registers]`).
- Fixes #279 — LMS8001: propagate the `SPI_read_batch` transaction status instead of always returning Success.
- Fixes #284 — threadHelper: fix an operator-precedence bug so the real pthread errno is captured, not 0/1.
- Fixes #286 — comms: switch on `errno` (not the ioctl return) in DMA EnableContinuous, so a busy DMA is reported as Busy.
- Fixes #287 — comms: make the USB session refcount `std::atomic` and decide the init/join transitions atomically.
- Fixes #291 — MMX8: send the per-parameter vector in CustomParameterWrite/Read so per-subdevice params actually work.
- Fixes #299 — legacyapi: null-check the handle before dereferencing it in LMS_DestroyStream.
- Fixes #304 — limeTRX: require `--chip` on multi-RF-chip devices instead of dereferencing an empty chipIndexes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)