### PR TITLE
Batch: 10 hardware-free stability/reliability fixes

### DIFF
--- a/drivers/linux/limepcie/limepcie_core.c
+++ b/drivers/linux/limepcie/limepcie_core.c
@@ -68,7 +68,7 @@ struct limepcie_device_attributes {
 
 struct deviceInfo {
     uint64_t serialNumber;
-    uint16_t firmware;
+    uint32_t firmware;
     uint8_t boardId;
     uint8_t protocol;
     uint8_t hardwareVer;

--- a/drivers/linux/limepcie/limepcie_core.c
+++ b/drivers/linux/limepcie/limepcie_core.c
@@ -1181,15 +1181,15 @@ static bool ValidChar(char c)
 
 static void SanitizeIdentifier(const char *identifier, char *destination, const size_t dstSize)
 {
-    uint8_t size = 0;
-    while (size < dstSize && ValidChar(identifier[size]))
+    size_t size = 0;
+    while (size + 1 < dstSize && ValidChar(identifier[size]))
         size++;
 
     while (size > 0 && identifier[size - 1] == ' ')
         size--;
 
-    size = size <= dstSize ? size : dstSize;
     strncpy(destination, identifier, size);
+    destination[size] = '\0';
 
     for (size_t i = 0; i < size; i++)
         if (destination[i] == ' ')

--- a/drivers/linux/limepcie/limeuart.c
+++ b/drivers/linux/limepcie/limeuart.c
@@ -408,7 +408,7 @@ static int limeuart_probe(struct platform_device *pdev)
     int ctrl_id = 0;
     int port_id = 0;
     if ((ret = limeuart_uart_port_init(&luart->port, &pdev->dev, res, line_id, ctrl_id, port_id)))
-        return ret;
+        goto err_erase_id;
 
     if ((ret = uart_add_one_port(&limeuart_driver, &luart->port)))
         goto err_erase_id;

--- a/src/API/LimePlugin.cpp
+++ b/src/API/LimePlugin.cpp
@@ -517,6 +517,11 @@ static OpStatus AssignDevicesToPorts(LimePluginContext* context)
             token.remove_prefix(3);
             std::stringstream sstream{ std::string{ token } };
             sstream >> devIndex;
+            if (sstream.fail() || devIndex < 0 || devIndex >= static_cast<int>(context->rfdev.size()))
+            {
+                Log(LogLevel::Error, "Port%i assigned invalid device index (dev%s).", p, std::string{ token }.c_str());
+                return OpStatus::InvalidValue;
+            }
             DevNode* assignedDevice = &context->rfdev.at(devIndex);
             port.nodes.push_back(assignedDevice);
             assignedDevice->portIndex = p;
@@ -538,8 +543,13 @@ static OpStatus AssignDevicesToPorts(LimePluginContext* context)
             }
             token.remove_prefix(3);
             std::stringstream sstream{ std::string{ token } };
-            int devIndex;
+            int devIndex = 0;
             sstream >> devIndex;
+            if (sstream.fail() || devIndex < 0 || devIndex >= static_cast<int>(context->rfdev.size()))
+            {
+                Log(LogLevel::Error, "Port%i assigned invalid calibration device index (dev%s).", p, std::string{ token }.c_str());
+                return OpStatus::InvalidValue;
+            }
             DevNode* assignedDevice = &context->rfdev.at(devIndex);
             port.calibrationNode = assignedDevice;
             assignedDevice->portIndex = p;

--- a/src/FPGA/FPGA_common.cpp
+++ b/src/FPGA/FPGA_common.cpp
@@ -966,15 +966,27 @@ void FPGA::SetFeatures(const GatewareFeatures& flags)
 /// @return The packet size after the changes (returns @p packetSize if not supported)
 uint32_t FPGA::SetUpVariableRxSize(uint32_t requestSamplesCount, int sampleSize, int channelCount, uint8_t chipId)
 {
+    constexpr uint32_t headerSize = sizeof(StreamHeader);
+    constexpr uint32_t defaultPacketSize = 4096;
+    if (sampleSize <= 0 || channelCount <= 0)
+    {
+        lime::error("SetUpVariableRxSize: invalid sample size (%i) or channel count (%i)", sampleSize, channelCount);
+        return defaultPacketSize;
+    }
     const int busSize = mFeatures.databusWidth;
     uint32_t packetSize = GetPacketSizeForBusSize(requestSamplesCount, sampleSize, channelCount, busSize);
+    if (packetSize <= headerSize || packetSize > defaultPacketSize)
+    {
+        lime::error("SetUpVariableRxSize: computed invalid packet size (%u), using %u", packetSize, defaultPacketSize);
+        packetSize = defaultPacketSize;
+    }
 
-    int32_t payloadSize = packetSize - 16;
-    const uint32_t iqSamplesCount = (payloadSize / (sampleSize * 2));
+    const uint32_t iqSamplesCount = (packetSize - headerSize) / (sampleSize * 2);
     SelectModule(chipId);
     uint32_t requestAddr[] = { 0x0019, 0x000E };
     uint32_t requestData[] = { packetSize, iqSamplesCount };
-    WriteRegisters(requestAddr, requestData, 2);
+    if (WriteRegisters(requestAddr, requestData, 2) != OpStatus::Success)
+        lime::error("SetUpVariableRxSize: failed to write packet size registers"s);
 
     return packetSize;
 }

--- a/src/chips/CDCM6208/CDCM6208.cpp
+++ b/src/chips/CDCM6208/CDCM6208.cpp
@@ -805,7 +805,7 @@ void CDCM_Dev::UpdateOutputFrequencies()
 int CDCM_Dev::PrepareToReadRegs()
 {
     const auto timeout = std::chrono::milliseconds(200);
-    uint16_t status = 0;
+    int32_t status = 0;
 
     WriteRegister(SPI_BASE_ADDR + 24, 1);
     auto t1 = std::chrono::high_resolution_clock::now();
@@ -1048,11 +1048,11 @@ int CDCM_Dev::WriteRegister(uint16_t addr, uint16_t val)
   @param addr The address of which value to read.
   @return The value of the given address; -1 on error.
  */
-uint16_t CDCM_Dev::ReadRegister(uint16_t addr)
+int32_t CDCM_Dev::ReadRegister(uint16_t addr)
 {
     OpStatus status;
-    return ReadSPI(comms.get(), addr, &status);
-    return status == OpStatus::Success ? 0 : -1;
+    const uint16_t value = ReadSPI(comms.get(), addr, &status);
+    return status == OpStatus::Success ? value : -1;
 }
 
 } // namespace lime

--- a/src/chips/CDCM6208/CDCM6208.h
+++ b/src/chips/CDCM6208/CDCM6208.h
@@ -144,7 +144,7 @@ class LIME_API CDCM_Dev
 
   private:
     int WriteRegister(uint16_t addr, uint16_t val);
-    uint16_t ReadRegister(uint16_t addr);
+    int32_t ReadRegister(uint16_t addr);
 
     int SolveN(int Target, int* Mult8bit, int* Mult10bit);
     void CalculateFracDiv(CDCM_Output* Output);

--- a/src/chips/LMS7002M/MCU_BD.cpp
+++ b/src/chips/LMS7002M/MCU_BD.cpp
@@ -633,7 +633,12 @@ int MCU_BD::RunProductionTest_MCU()
 
     //upload hex file
     if (Program_MCU(m_iMode1_, m_iMode0_) != 0)
+    {
+        //Baseband gets back the control over SPI switch
+        mSPI_write(0x0006, 0x0000); //REG6 write
+
         return -1; //failed to program
+    }
 
     if (m_bLoadedProd == 0)
     {
@@ -675,6 +680,9 @@ int MCU_BD::RunProductionTest_MCU()
 
     if (retval != 0x10)
     {
+        //Baseband gets back the control over SPI switch
+        mSPI_write(0x0006, 0x0000); //REG6 write
+
         return -1;
     }
 
@@ -726,6 +734,9 @@ int MCU_BD::RunProductionTest_MCU()
     retval = mSPI_read(1); //REG1 read
     if (retval != 0x55)
     {
+        //Baseband gets back the control over SPI switch
+        mSPI_write(0x0006, 0x0000); //REG6 write
+
         return -1;
     }
 

--- a/src/comms/PCIe/LimePCIe.cpp
+++ b/src/comms/PCIe/LimePCIe.cpp
@@ -28,8 +28,10 @@ std::vector<std::string> LimePCIe::GetEndpointsWithPattern(const std::string& de
 
     std::string cmd = "ls -1 "s + devicePath + "/"s + regex;
     lsPipe = popen(cmd.c_str(), "r");
+    if (lsPipe == nullptr)
+        return devices;
     char tempBuffer[512];
-    while (fscanf(lsPipe, "%s", tempBuffer) == 1)
+    while (fscanf(lsPipe, "%511s", tempBuffer) == 1)
         devices.push_back(tempBuffer);
     pclose(lsPipe);
     return devices;
@@ -40,8 +42,10 @@ std::vector<std::string> LimePCIe::GetPCIeDeviceList()
     std::vector<std::string> devices;
     FILE* lsPipe;
     lsPipe = popen("ls -1 -- /sys/class/limepcie 2> /dev/null", "r");
+    if (lsPipe == nullptr)
+        return devices;
     char tempBuffer[512];
-    while (fscanf(lsPipe, "%s", tempBuffer) == 1)
+    while (fscanf(lsPipe, "%511s", tempBuffer) == 1)
     {
         // Kernel code fakes directories by replacing '/' char with '!'
         // open() can't open that

--- a/src/comms/PCIe/LimePCIeDMA.cpp
+++ b/src/comms/PCIe/LimePCIeDMA.cpp
@@ -62,6 +62,10 @@ OpStatus LimePCIeDMA::Initialize()
         if (buf == MAP_FAILED || buf == nullptr)
         {
             const std::string msg = ": failed to MMAP Rx DMA buffer"s;
+            // release the DMA writer lock acquired above, otherwise the channel stays blocked
+            memset(&lockInfo, 0, sizeof(lockInfo));
+            lockInfo.dma_writer_release = 1;
+            ioctl(port->mFileDescriptor, LIMEPCIE_IOCTL_LOCK, &lockInfo);
             return OpStatus::Error;
         }
         for (size_t i = 0; i < info.dma_rx_buf_count; ++i)
@@ -86,6 +90,10 @@ OpStatus LimePCIeDMA::Initialize()
         if (buf == MAP_FAILED || buf == nullptr)
         {
             const std::string msg = ": failed to MMAP Tx DMA buffer"s;
+            // release the DMA reader lock acquired above, otherwise the channel stays blocked
+            memset(&lockInfo, 0, sizeof(lockInfo));
+            lockInfo.dma_reader_release = 1;
+            ioctl(port->mFileDescriptor, LIMEPCIE_IOCTL_LOCK, &lockInfo);
             return OpStatus::Error;
         }
         for (size_t i = 0; i < info.dma_tx_buf_count; ++i)

--- a/src/streaming/TRXLooper.h
+++ b/src/streaming/TRXLooper.h
@@ -39,7 +39,7 @@ class TRXLooper : public RFStream
 
     /// @brief Gets whether the stream is currently running or not.
     /// @return The current status of the stream (true if running).
-    constexpr inline bool IsStreamRunning() const { return mStreamEnabled; }
+    inline bool IsStreamRunning() const { return mStreamEnabled; }
     uint32_t StreamRx(
         lime::complex32f_t* const* samples, uint32_t count, StreamMeta* meta, std::chrono::microseconds timeout) override;
     uint32_t StreamRx(
@@ -100,7 +100,7 @@ class TRXLooper : public RFStream
     void TransmitPacketsLoop();
     void TxTeardown();
 
-    uint64_t mTimestampOffset;
+    std::atomic<uint64_t> mTimestampOffset;
     lime::StreamConfig mConfig;
 
     TransferArgs mRxArgs;
@@ -113,7 +113,7 @@ class TRXLooper : public RFStream
     SDRDevice::LogCallbackType mCallback_logMessage;
     std::condition_variable streamActive;
     std::mutex streamMutex;
-    bool mStreamEnabled;
+    std::atomic<bool> mStreamEnabled;
     bool omitRxPackets;
 
     struct Stream {


### PR DESCRIPTION
Second batched round of fixes from the stability audit (#274-#312), one signed commit per fix, following the agreed intermediate-branch workflow to keep CI load low. All fixes are verifiable without hardware.

- **#276** - CDCM6208: ReadRegister now returns a signed value so SPI read failures are a real -1 the callers can detect
- **#277** - LMS7002M: MCU production self-test returns the SPI switch to baseband on every failure path
- **#281** - streaming: TRXLooper's mStreamEnabled and mTimestampOffset are std::atomic, removing the cross-thread data races
- **#285** - comms: PCIe DMA Initialize releases the kernel DMA lock when mmap fails, so the channel is not blocked for the process lifetime
- **#290** - comms: PCIe enumeration checks the popen result and bounds the fscanf to the 512-byte buffer
- **#298** - API: plugin port device indexes are parse- and range-validated, returning InvalidValue instead of throwing before the try block
- **#300** - FPGA: variable Rx packet size is validated (falling back to 4096 on degenerate geometry) and the register-write status is logged on failure
- **#310** - limepcie: firmware version field widened to uint32_t so the high byte is no longer truncated
- **#311** - limepcie: limeuart probe releases its xarray slot when port init fails (goto err_erase_id)
- **#312** - limepcie: SanitizeIdentifier uses size_t, caps the scan below the buffer size, and always NUL-terminates

Fixes #276
Fixes #277
Fixes #281
Fixes #285
Fixes #290
Fixes #298
Fixes #300
Fixes #310
Fixes #311
Fixes #312

Verification: full CMake build clean; all 54 unit tests pass (`gtest-runner`). The three limepcie driver changes are build-verified by inspection only, since the build box has no kernel headers.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)