### PR TITLE
Batch: 10 streaming/boards/plugin stability fixes (closes out the audit set)

### DIFF
--- a/plugins/soapysdr/Settings.cpp
+++ b/plugins/soapysdr/Settings.cpp
@@ -30,8 +30,7 @@ constexpr uint8_t socIndex = 0;
  * Constructor/destructor
  ******************************************************************/
 Soapy_limesuiteng::Soapy_limesuiteng(const DeviceHandle& handle, const SoapySDR::Kwargs& args)
-    : isStreamRunning(false)
-    , sampleRate{ 0.0, 0.0 }
+    : sampleRate{ 0.0, 0.0 }
     , oversampling(0) // Auto
 {
     SoapySDR::log(SOAPY_SDR_INFO, "Make connection: '" + handle.ToString() + "'");
@@ -485,7 +484,7 @@ void Soapy_limesuiteng::setSampleRate(const int direction, const size_t channel,
     std::unique_lock<std::recursive_mutex> lock(_accessMutex);
     TRXDir dir = direction == SOAPY_SDR_TX ? TRXDir::Tx : TRXDir::Rx;
 
-    if (isStreamRunning)
+    if (isStreamRunning())
     {
         SoapySDR::logf(SOAPY_SDR_ERROR,
             "setSampleRate(%s, %ld, %g MHz) setting the sample rate while the stream is running is not allowed.",

--- a/plugins/soapysdr/Soapy_limesuiteng.h
+++ b/plugins/soapysdr/Soapy_limesuiteng.h
@@ -273,9 +273,13 @@ class Soapy_limesuiteng : public SoapySDR::Device
         int DCTestAmplitude;
     };
     lime::SDRDevice* sdrDevice;
+    // Rx and Tx SoapySDR streams share one bidirectional hardware stream;
+    // per-direction flags track which SoapySDR streams are set up / activated
     std::unique_ptr<lime::RFStream> rfstream;
     lime::StreamConfig streamConfig;
-    bool isStreamRunning;
+    std::array<bool, 2> directionSetup{ { false, false } }; // indexed by SoapySDR direction
+    std::array<bool, 2> directionActive{ { false, false } }; // indexed by SoapySDR direction
+    bool isStreamRunning() const { return directionActive[SOAPY_SDR_RX] || directionActive[SOAPY_SDR_TX]; }
 
     mutable std::recursive_mutex _accessMutex;
 

--- a/plugins/soapysdr/Streaming.cpp
+++ b/plugins/soapysdr/Streaming.cpp
@@ -107,6 +107,14 @@ SoapySDR::Stream* Soapy_limesuiteng::setupStream(
     const int direction, const std::string& format, const std::vector<size_t>& channels, const SoapySDR::Kwargs& args)
 {
     std::unique_lock<std::recursive_mutex> lock(_accessMutex);
+    // Rx and Tx SoapySDR streams share the single bidirectional hardware stream
+    if (direction != SOAPY_SDR_TX && direction != SOAPY_SDR_RX)
+        throw std::runtime_error("Soapy_limesuiteng::setupStream() invalid direction");
+    if (directionSetup.at(direction))
+        throw std::runtime_error("Soapy_limesuiteng::setupStream() a stream for this direction is already setup");
+    if (isStreamRunning())
+        throw std::runtime_error("Soapy_limesuiteng::setupStream() cannot setup a new direction while the stream is running");
+
     // Store result into opaque stream object
     auto stream = new IConnectionStream;
     stream->direction = direction;
@@ -117,6 +125,9 @@ SoapySDR::Stream* Soapy_limesuiteng::setupStream(
     config.bufferSize = 0; // Auto
 
     TRXDir dir = (direction == SOAPY_SDR_TX) ? TRXDir::Tx : TRXDir ::Rx;
+    const int otherDirection = (direction == SOAPY_SDR_TX) ? SOAPY_SDR_RX : SOAPY_SDR_TX;
+    const DataFormat previousFormat = config.format;
+    const DataFormat previousLinkFormat = config.linkFormat;
 
     // Default to channel 0, if none were specified
     const std::vector<size_t>& channelIDs = channels.empty() ? std::vector<size_t>{ 0 } : channels;
@@ -159,6 +170,13 @@ SoapySDR::Stream* Soapy_limesuiteng::setupStream(
         }
     }
 
+    // the directions share one hardware stream, so their formats have to agree
+    if (directionSetup.at(otherDirection) && (config.format != previousFormat || config.linkFormat != previousLinkFormat))
+    {
+        delete stream;
+        throw std::runtime_error("Soapy_limesuiteng::setupStream() both directions must use the same sample and link format");
+    }
+
     // TODO: reimplement if relevant
     // Optional buffer length if specified (from device args)
 
@@ -195,6 +213,7 @@ SoapySDR::Stream* Soapy_limesuiteng::setupStream(
 
     stream->ownerDevice = sdrDevice;
     stream->streamConfig = config;
+    directionSetup.at(direction) = true;
 
     return reinterpret_cast<SoapySDR::Stream*>(stream);
 }
@@ -203,7 +222,12 @@ void Soapy_limesuiteng::closeStream(SoapySDR::Stream* stream)
 {
     std::unique_lock<std::recursive_mutex> lock(_accessMutex);
     auto icstream = reinterpret_cast<IConnectionStream*>(stream);
-    if (rfstream)
+    const int direction = icstream->direction;
+    directionSetup.at(direction) = false;
+    directionActive.at(direction) = false;
+    streamConfig.channels[direction == SOAPY_SDR_TX ? TRXDir::Tx : TRXDir::Rx].clear();
+    // tear the hardware stream down only when neither direction needs it anymore
+    if (!directionSetup.at(SOAPY_SDR_RX) && !directionSetup.at(SOAPY_SDR_TX) && rfstream)
     {
         rfstream->Stop();
         rfstream.reset();
@@ -222,7 +246,7 @@ int Soapy_limesuiteng::activateStream(SoapySDR::Stream* stream, const int flags,
     std::unique_lock<std::recursive_mutex> lock(_accessMutex);
     auto icstream = reinterpret_cast<IConnectionStream*>(stream);
 
-    if (isStreamRunning)
+    if (directionActive.at(icstream->direction))
         return 0;
 
     if (sampleRate[SOAPY_SDR_RX] <= 0.0)
@@ -248,8 +272,9 @@ int Soapy_limesuiteng::activateStream(SoapySDR::Stream* stream, const int flags,
     //     _channelsToCal.erase(_channelsToCal.begin());
     // }
     // recreate the stream only if the rate it was built with no longer matches,
-    // e.g. the app configured the sample rate after setting up the stream
-    if (!rfstream || streamConfig.hintSampleRate != sampleRate[SOAPY_SDR_RX])
+    // e.g. the app configured the sample rate after setting up the stream;
+    // when the other direction is already running the shared stream stays as-is
+    if (!isStreamRunning() && (!rfstream || streamConfig.hintSampleRate != sampleRate[SOAPY_SDR_RX]))
     {
         streamConfig.hintSampleRate = sampleRate[SOAPY_SDR_RX];
         rfstream = sdrDevice->StreamCreate(streamConfig, 0);
@@ -263,8 +288,9 @@ int Soapy_limesuiteng::activateStream(SoapySDR::Stream* stream, const int flags,
     icstream->rxBurstRequest = (flags & SOAPY_SDR_HAS_TIME) | (flags & SOAPY_SDR_END_BURST);
     icstream->rxBurstSamples = numElems;
 
-    rfstream->Start();
-    isStreamRunning = true;
+    if (!isStreamRunning())
+        rfstream->Start();
+    directionActive.at(icstream->direction) = true;
     return 0;
 }
 
@@ -274,9 +300,10 @@ int Soapy_limesuiteng::deactivateStream(
     std::unique_lock<std::recursive_mutex> lock(_accessMutex);
     auto icstream = reinterpret_cast<IConnectionStream*>(stream);
     icstream->rxBurstRequest = false;
-    if (rfstream)
+    directionActive.at(icstream->direction) = false;
+    // stop the shared hardware stream only once both directions are deactivated
+    if (!isStreamRunning() && rfstream)
         rfstream->Stop();
-    isStreamRunning = false;
     return 0;
 }
 

--- a/src/boards/LMS7002M_SDRDevice.cpp
+++ b/src/boards/LMS7002M_SDRDevice.cpp
@@ -225,8 +225,14 @@ int LMS7002M_SDRDevice::GetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t cha
     return GetParameter(moduleIndex, channel, selParameter.address, selParameter.msb, selParameter.lsb);
 }
 
-OpStatus LMS7002M_SDRDevice::SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, bool downconv)
+OpStatus LMS7002M_SDRDevice::SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, int16_t index, bool downconv)
 {
+    if (index >= 16)
+    {
+        lime::error("Invalid NCO index value."s);
+        return OpStatus::OutOfRange;
+    }
+
     auto& cmixBypassParameter = trx == TRXDir::Tx ? CMIX_BYP_TXTSP : CMIX_BYP_RXTSP;
     auto& cmixGainParameter = trx == TRXDir::Tx ? CMIX_GAIN_TXTSP : CMIX_GAIN_RXTSP;
     auto& selectionParameter = trx == TRXDir::Tx ? SEL_TX : SEL_RX;
@@ -241,11 +247,8 @@ OpStatus LMS7002M_SDRDevice::SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_
         status != OpStatus::Success)
         return status;
 
-    if (index >= 16)
-    {
-        lime::error("Invalid NCO index value."s);
-        return OpStatus::OutOfRange;
-    }
+    if (index < 0) // NCO disabled, there is no table entry to select
+        return OpStatus::Success;
 
     if (OpStatus status =
             SetParameter(moduleIndex, channel, selectionParameter.address, selectionParameter.msb, selectionParameter.lsb, index);

--- a/src/boards/LMS7002M_SDRDevice.cpp
+++ b/src/boards/LMS7002M_SDRDevice.cpp
@@ -262,7 +262,8 @@ OpStatus LMS7002M_SDRDevice::SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_
 
 double LMS7002M_SDRDevice::GetLowPassFilter(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    return lowPassFilterCache[trx][channel]; // Default initializes to 0
+    const auto it = lowPassFilterCache.find({ moduleIndex, trx, channel });
+    return it != lowPassFilterCache.end() ? it->second : 0; // 0 when never set
 }
 
 OpStatus LMS7002M_SDRDevice::SetLowPassFilter(uint8_t moduleIndex, TRXDir trx, uint8_t channel, double lpf)
@@ -278,7 +279,8 @@ OpStatus LMS7002M_SDRDevice::SetLowPassFilter(uint8_t moduleIndex, TRXDir trx, u
 
     if (lpf < 0)
     {
-        lpf = lowPassFilterCache[trx][channel]; // Default initializes to 0
+        const auto it = lowPassFilterCache.find({ moduleIndex, trx, channel });
+        lpf = it != lowPassFilterCache.end() ? it->second : 0; // 0 when never set
     }
 
     double newLPF = std::clamp(lpf, bw_range.min, bw_range.max);
@@ -289,7 +291,7 @@ OpStatus LMS7002M_SDRDevice::SetLowPassFilter(uint8_t moduleIndex, TRXDir trx, u
     }
 
     lpf = newLPF;
-    lowPassFilterCache[trx][channel] = lpf;
+    lowPassFilterCache[{ moduleIndex, trx, channel }] = lpf;
 
     OpStatus status = OpStatus::Success;
     if (tx)

--- a/src/boards/LMS7002M_SDRDevice.h
+++ b/src/boards/LMS7002M_SDRDevice.h
@@ -40,7 +40,7 @@ class LMS7002M_SDRDevice : public SDRDevice
         uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, double frequency, double phaseOffset = -1.0) override;
 
     int GetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel) override;
-    OpStatus SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, bool downconv) override;
+    OpStatus SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, int16_t index, bool downconv) override;
 
     double GetNCOOffset(uint8_t moduleIndex, TRXDir trx, uint8_t channel) override;
 

--- a/src/boards/LMS7002M_SDRDevice.h
+++ b/src/boards/LMS7002M_SDRDevice.h
@@ -2,6 +2,8 @@
 #define LIME_LMS7002M_SDRDevice_H
 
 #include <cstdint>
+#include <map>
+#include <tuple>
 #include <vector>
 #include <memory>
 
@@ -172,7 +174,8 @@ class LMS7002M_SDRDevice : public SDRDevice
     OpStatus SetGenericRxGain(LMS7002M& device, LMS7002M::Channel channel, double value);
     OpStatus SetGenericTxGain(LMS7002M& device, LMS7002M::Channel channel, double value);
 
-    std::unordered_map<TRXDir, std::unordered_map<uint8_t, double>> lowPassFilterCache;
+    // keyed by (moduleIndex, direction, channel) so multi-chip boards don't share entries
+    std::map<std::tuple<uint8_t, TRXDir, uint8_t>, double> lowPassFilterCache;
 
     /// @copydoc FPGA::ReadRegister()
     int ReadFPGARegister(uint32_t address);

--- a/src/boards/LimeSDR_Mini/LimeSDR_Mini.cpp
+++ b/src/boards/LimeSDR_Mini/LimeSDR_Mini.cpp
@@ -281,7 +281,9 @@ OpStatus LimeSDR_Mini::Configure(const SDRConfig& cfg, uint8_t moduleIndex = 0)
         SetAntenna(0, TRXDir::Rx, c, cfg.channel[c].rx.path);
         SetNCOFrequency(0, TRXDir::Tx, c, 0, cfg.channel[c].tx.NCOoffset, 0);
         SetNCOFrequency(0, TRXDir::Rx, c, 0, cfg.channel[c].rx.NCOoffset, 0);
-        LMS7002ChannelCalibration(*chip, cfg.channel[c], c);
+        status = LMS7002ChannelCalibration(*chip, cfg.channel[c], c);
+        if (status != OpStatus::Success)
+            return status;
     }
 
     if (sampleRate > 0)

--- a/src/boards/LimeSDR_X3/LimeSDR_X3.cpp
+++ b/src/boards/LimeSDR_X3/LimeSDR_X3.cpp
@@ -475,7 +475,12 @@ OpStatus LimeSDR_X3::ConfigureLMS1(const SDRConfig& cfg)
     if (!cfg.skipDefaults)
     {
         const bool skipTune = true;
-        InitLMS1(skipTune);
+        OpStatus status = InitLMS1(skipTune);
+        if (status != OpStatus::Success)
+        {
+            mConfigInProgress = false;
+            return status;
+        }
     }
     chip->Modify_SPI_Reg_bits(PD_TX_AFE1, 0); // enabled DAC is required for FPGA to work
 
@@ -504,7 +509,11 @@ OpStatus LimeSDR_X3::ConfigureLMS1(const SDRConfig& cfg)
         sampleRate = cfg.channel[0].tx.sampleRate;
 
     if (sampleRate > 0)
-        LMS7002M_SDRDevice::LMS7002M_SetSampleRate(sampleRate, cfg.channel[0].rx.oversample, cfg.channel[0].tx.oversample);
+    {
+        status = LMS7002M_SDRDevice::LMS7002M_SetSampleRate(sampleRate, cfg.channel[0].rx.oversample, cfg.channel[0].tx.oversample);
+        if (status != OpStatus::Success)
+            return status;
+    }
 
     for (int c = 0; c < 2; ++c)
     {
@@ -512,10 +521,14 @@ OpStatus LimeSDR_X3::ConfigureLMS1(const SDRConfig& cfg)
         SetLMSPath(TRXDir::Rx, cfg.channel[c].rx, c, socIndex);
         SetNCOFrequency(0, TRXDir::Tx, c, 0, cfg.channel[c].tx.NCOoffset, 0);
         SetNCOFrequency(0, TRXDir::Rx, c, 0, cfg.channel[c].rx.NCOoffset, 0);
-        LMS7002ChannelCalibration(*chip, cfg.channel[c], c);
+        status = LMS7002ChannelCalibration(*chip, cfg.channel[c], c);
+        if (status != OpStatus::Success)
+            return status;
     }
 
-    LMS1_UpdateFPGAInterface(this);
+    status = LMS1_UpdateFPGAInterface(this);
+    if (status != OpStatus::Success)
+        return status;
 
     for (int c = 0; c < 2; ++c)
     {

--- a/src/boards/LimeSDR_XTRX/LimeSDR_XTRX.cpp
+++ b/src/boards/LimeSDR_XTRX/LimeSDR_XTRX.cpp
@@ -254,7 +254,12 @@ OpStatus LimeSDR_XTRX::Configure(const SDRConfig& cfg, uint8_t socIndex)
     if (!cfg.skipDefaults)
     {
         const bool skipTune = true;
-        InitLMS1(*chip, skipTune);
+        OpStatus status = InitLMS1(*chip, skipTune);
+        if (status != OpStatus::Success)
+        {
+            mConfigInProgress = false;
+            return status;
+        }
     }
 
     OpStatus status = LMS7002M_Configure(*chip, cfg);
@@ -278,7 +283,11 @@ OpStatus LimeSDR_XTRX::Configure(const SDRConfig& cfg, uint8_t socIndex)
         sampleRate = cfg.channel[0].tx.sampleRate;
 
     if (sampleRate > 0)
-        LMS1_SetSampleRate(sampleRate, cfg.channel[0].rx.oversample, cfg.channel[0].tx.oversample);
+    {
+        status = LMS1_SetSampleRate(sampleRate, cfg.channel[0].rx.oversample, cfg.channel[0].tx.oversample);
+        if (status != OpStatus::Success)
+            return status;
+    }
 
     for (int c = 0; c < 2; ++c)
     {
@@ -286,7 +295,9 @@ OpStatus LimeSDR_XTRX::Configure(const SDRConfig& cfg, uint8_t socIndex)
         LMSSetPath(TRXDir::Rx, c, cfg.channel[c].rx.path);
         SetNCOFrequency(0, TRXDir::Tx, c, 0, cfg.channel[c].tx.NCOoffset, 0);
         SetNCOFrequency(0, TRXDir::Rx, c, 0, cfg.channel[c].rx.NCOoffset, 0);
-        LMS7002ChannelCalibration(*chip, cfg.channel[c], c);
+        status = LMS7002ChannelCalibration(*chip, cfg.channel[c], c);
+        if (status != OpStatus::Success)
+            return status;
     }
 
     if (sampleRate > 0)

--- a/src/boards/MMX8/MM_X8.cpp
+++ b/src/boards/MMX8/MM_X8.cpp
@@ -222,7 +222,7 @@ int LimeSDR_MMX8::GetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
     return mSubDevices[moduleIndex]->GetNCOIndex(0, trx, channel);
 }
 
-OpStatus LimeSDR_MMX8::SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, bool downconv)
+OpStatus LimeSDR_MMX8::SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, int16_t index, bool downconv)
 {
     if (moduleIndex >= mSubDevices.size())
         return OpStatus::OutOfRange;

--- a/src/boards/MMX8/MM_X8.cpp
+++ b/src/boards/MMX8/MM_X8.cpp
@@ -140,6 +140,8 @@ const SDRDescriptor& LimeSDR_MMX8::GetDescriptor() const
 
 OpStatus LimeSDR_MMX8::Configure(const SDRConfig& cfg, uint8_t socIndex)
 {
+    if (socIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
     return mSubDevices[socIndex]->Configure(cfg, 0);
 }
 
@@ -181,30 +183,24 @@ OpStatus LimeSDR_MMX8::GetGPSLock(GPS_Lock* status)
 // TODO: clean up all the functions to use the exact same device selection code (maybe even extract it out into a function)
 double LimeSDR_MMX8::GetFrequency(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetFrequency(0, trx, channel);
 }
 
 OpStatus LimeSDR_MMX8::SetFrequency(uint8_t moduleIndex, TRXDir trx, uint8_t channel, double frequency)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetFrequency(0, trx, channel, frequency);
 }
 
 double LimeSDR_MMX8::GetNCOFrequency(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, double& phaseOffset)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetNCOFrequency(0, trx, channel, index, phaseOffset);
 }
@@ -212,100 +208,80 @@ double LimeSDR_MMX8::GetNCOFrequency(uint8_t moduleIndex, TRXDir trx, uint8_t ch
 OpStatus LimeSDR_MMX8::SetNCOFrequency(
     uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, double frequency, double phaseOffset)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetNCOFrequency(0, trx, channel, index, frequency, phaseOffset);
 }
 
 int LimeSDR_MMX8::GetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return -1;
 
     return mSubDevices[moduleIndex]->GetNCOIndex(0, trx, channel);
 }
 
 OpStatus LimeSDR_MMX8::SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, bool downconv)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetNCOIndex(0, trx, channel, index, downconv);
 }
 
 double LimeSDR_MMX8::GetNCOOffset(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetNCOOffset(0, trx, channel);
 }
 
 double LimeSDR_MMX8::GetSampleRate(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint32_t* rf_samplerate)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetSampleRate(0, trx, channel, rf_samplerate);
 }
 
 OpStatus LimeSDR_MMX8::SetSampleRate(uint8_t moduleIndex, TRXDir trx, uint8_t channel, double sampleRate, uint8_t oversample)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetSampleRate(0, trx, channel, sampleRate, oversample);
 }
 
 double LimeSDR_MMX8::GetLowPassFilter(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetLowPassFilter(0, trx, channel);
 }
 
 OpStatus LimeSDR_MMX8::SetLowPassFilter(uint8_t moduleIndex, TRXDir trx, uint8_t channel, double lpf)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetLowPassFilter(0, trx, channel, lpf);
 }
 
 uint8_t LimeSDR_MMX8::GetAntenna(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetAntenna(0, trx, channel);
 }
 
 OpStatus LimeSDR_MMX8::SetAntenna(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t path)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetAntenna(0, trx, channel, path);
 }
@@ -322,172 +298,144 @@ OpStatus LimeSDR_MMX8::SetClockFreq(uint8_t clk_id, double freq, uint8_t channel
 
 OpStatus LimeSDR_MMX8::SetGain(uint8_t moduleIndex, TRXDir direction, uint8_t channel, eGainTypes gain, double value)
 {
-    auto& device = mSubDevices.at(moduleIndex);
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
+    auto& device = mSubDevices[moduleIndex];
     return device->SetGain(0, direction, channel, gain, value);
 }
 
 OpStatus LimeSDR_MMX8::GetGain(uint8_t moduleIndex, TRXDir direction, uint8_t channel, eGainTypes gain, double& value)
 {
-    auto& device = mSubDevices.at(moduleIndex);
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
+    auto& device = mSubDevices[moduleIndex];
     return device->GetGain(0, direction, channel, gain, value);
 }
 
 bool LimeSDR_MMX8::GetDCOffsetMode(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return false;
 
     return mSubDevices[moduleIndex]->GetDCOffsetMode(0, trx, channel);
 }
 
 OpStatus LimeSDR_MMX8::SetDCOffsetMode(uint8_t moduleIndex, TRXDir trx, uint8_t channel, bool isAutomatic)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetDCOffsetMode(0, trx, channel, isAutomatic);
 }
 
 complex64f_t LimeSDR_MMX8::GetDCOffset(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return {};
 
     return mSubDevices[moduleIndex]->GetDCOffset(0, trx, channel);
 }
 
 OpStatus LimeSDR_MMX8::SetDCOffset(uint8_t moduleIndex, TRXDir trx, uint8_t channel, const complex64f_t& offset)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetDCOffset(0, trx, channel, offset);
 }
 
 complex64f_t LimeSDR_MMX8::GetIQBalance(uint8_t moduleIndex, TRXDir trx, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return {};
 
     return mSubDevices[moduleIndex]->GetIQBalance(0, trx, channel);
 }
 
 OpStatus LimeSDR_MMX8::SetIQBalance(uint8_t moduleIndex, TRXDir trx, uint8_t channel, const complex64f_t& balance)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetIQBalance(0, trx, channel, balance);
 }
 
 bool LimeSDR_MMX8::GetCGENLocked(uint8_t moduleIndex)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return false;
 
     return mSubDevices[moduleIndex]->GetCGENLocked(0);
 }
 
 double LimeSDR_MMX8::GetTemperature(uint8_t moduleIndex)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetTemperature(0);
 }
 
 bool LimeSDR_MMX8::GetSXLocked(uint8_t moduleIndex, TRXDir trx)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return false;
 
     return mSubDevices[moduleIndex]->GetSXLocked(0, trx);
 }
 
 unsigned int LimeSDR_MMX8::ReadRegister(uint8_t moduleIndex, unsigned int address, bool useFPGA)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->ReadRegister(0, address, useFPGA);
 }
 
 OpStatus LimeSDR_MMX8::WriteRegister(uint8_t moduleIndex, unsigned int address, unsigned int value, bool useFPGA)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->WriteRegister(0, address, value, useFPGA);
 }
 
 OpStatus LimeSDR_MMX8::LoadConfig(uint8_t moduleIndex, const std::string& filename)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->LoadConfig(0, filename);
 }
 
 OpStatus LimeSDR_MMX8::SaveConfig(uint8_t moduleIndex, const std::string& filename)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SaveConfig(0, filename);
 }
 
 uint16_t LimeSDR_MMX8::GetParameter(uint8_t moduleIndex, uint8_t channel, const std::string& parameterKey)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetParameter(0, channel, parameterKey);
 }
 
 OpStatus LimeSDR_MMX8::SetParameter(uint8_t moduleIndex, uint8_t channel, const std::string& parameterKey, uint16_t value)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetParameter(0, channel, parameterKey, value);
 }
 
 uint16_t LimeSDR_MMX8::GetParameter(uint8_t moduleIndex, uint8_t channel, uint16_t address, uint8_t msb, uint8_t lsb)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetParameter(0, channel, address, msb, lsb);
 }
@@ -495,10 +443,8 @@ uint16_t LimeSDR_MMX8::GetParameter(uint8_t moduleIndex, uint8_t channel, uint16
 OpStatus LimeSDR_MMX8::SetParameter(
     uint8_t moduleIndex, uint8_t channel, uint16_t address, uint8_t msb, uint8_t lsb, uint16_t value)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetParameter(0, channel, address, msb, lsb, value);
 }
@@ -523,20 +469,16 @@ void LimeSDR_MMX8::EnableCache(bool enable)
 
 OpStatus LimeSDR_MMX8::EnableChannel(uint8_t moduleIndex, TRXDir trx, uint8_t channel, bool enable)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->EnableChannel(0, trx, channel, enable);
 }
 
 OpStatus LimeSDR_MMX8::Calibrate(uint8_t moduleIndex, TRXDir trx, uint8_t channel, double bandwidth)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->Calibrate(0, trx, channel, bandwidth);
 }
@@ -544,20 +486,16 @@ OpStatus LimeSDR_MMX8::Calibrate(uint8_t moduleIndex, TRXDir trx, uint8_t channe
 OpStatus LimeSDR_MMX8::ConfigureGFIR(
     uint8_t moduleIndex, TRXDir trx, uint8_t channel, ChannelConfig::Direction::GFIRFilter settings)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->ConfigureGFIR(0, trx, channel, settings);
 }
 
 std::vector<double> LimeSDR_MMX8::GetGFIRCoefficients(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t gfirID)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return {};
 
     return mSubDevices[moduleIndex]->GetGFIRCoefficients(0, trx, channel, gfirID);
 }
@@ -565,40 +503,32 @@ std::vector<double> LimeSDR_MMX8::GetGFIRCoefficients(uint8_t moduleIndex, TRXDi
 OpStatus LimeSDR_MMX8::SetGFIRCoefficients(
     uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t gfirID, std::vector<double> coefficients)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetGFIRCoefficients(0, trx, channel, gfirID, coefficients);
 }
 
 OpStatus LimeSDR_MMX8::SetGFIR(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t gfirID, bool enabled)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetGFIR(0, trx, channel, gfirID, enabled);
 }
 
 uint64_t LimeSDR_MMX8::GetHardwareTimestamp(uint8_t moduleIndex)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
 
     return mSubDevices[moduleIndex]->GetHardwareTimestamp(0);
 }
 
 OpStatus LimeSDR_MMX8::SetHardwareTimestamp(uint8_t moduleIndex, const uint64_t now)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetHardwareTimestamp(0, now);
 }
@@ -610,10 +540,8 @@ OpStatus LimeSDR_MMX8::SetTestSignal(uint8_t moduleIndex,
     int16_t dc_i,
     int16_t dc_q)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return OpStatus::OutOfRange;
 
     return mSubDevices[moduleIndex]->SetTestSignal(0, direction, channel, signalConfiguration, dc_i, dc_q);
 }
@@ -669,18 +597,24 @@ void LimeSDR_MMX8::StreamDestroy(uint8_t moduleIndex)
 uint32_t LimeSDR_MMX8::StreamRx(
     uint8_t moduleIndex, lime::complex32f_t* const* dest, uint32_t count, StreamMeta* meta, std::chrono::microseconds timeout)
 {
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
     return mSubDevices[moduleIndex]->StreamRx(0, dest, count, meta, timeout);
 }
 
 uint32_t LimeSDR_MMX8::StreamRx(
     uint8_t moduleIndex, lime::complex16_t* const* dest, uint32_t count, StreamMeta* meta, std::chrono::microseconds timeout)
 {
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
     return mSubDevices[moduleIndex]->StreamRx(0, dest, count, meta, timeout);
 }
 
 uint32_t LimeSDR_MMX8::StreamRx(
     uint8_t moduleIndex, lime::complex12_t* const* dest, uint32_t count, StreamMeta* meta, std::chrono::microseconds timeout)
 {
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
     return mSubDevices[moduleIndex]->StreamRx(0, dest, count, meta, timeout);
 }
 
@@ -690,6 +624,8 @@ uint32_t LimeSDR_MMX8::StreamTx(uint8_t moduleIndex,
     const StreamMeta* meta,
     std::chrono::microseconds timeout)
 {
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
     return mSubDevices[moduleIndex]->StreamTx(0, samples, count, meta, timeout);
 }
 
@@ -699,6 +635,8 @@ uint32_t LimeSDR_MMX8::StreamTx(uint8_t moduleIndex,
     const StreamMeta* meta,
     std::chrono::microseconds timeout)
 {
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
     return mSubDevices[moduleIndex]->StreamTx(0, samples, count, meta, timeout);
 }
 
@@ -708,20 +646,22 @@ uint32_t LimeSDR_MMX8::StreamTx(uint8_t moduleIndex,
     const StreamMeta* meta,
     std::chrono::microseconds timeout)
 {
+    if (moduleIndex >= mSubDevices.size())
+        return 0;
     return mSubDevices[moduleIndex]->StreamTx(0, samples, count, meta, timeout);
 }
 
 void LimeSDR_MMX8::StreamStatus(uint8_t moduleIndex, StreamStats* rx, StreamStats* tx)
 {
+    if (moduleIndex >= mSubDevices.size())
+        return;
     mSubDevices[moduleIndex]->StreamStatus(0, rx, tx);
 }
 
 ChannelConfig::Direction::TestSignal LimeSDR_MMX8::GetTestSignal(uint8_t moduleIndex, TRXDir direction, uint8_t channel)
 {
-    if (moduleIndex >= 8)
-    {
-        moduleIndex = 0;
-    }
+    if (moduleIndex >= mSubDevices.size())
+        return {};
 
     return mSubDevices[moduleIndex]->GetTestSignal(0, direction, channel);
 }

--- a/src/boards/MMX8/MM_X8.h
+++ b/src/boards/MMX8/MM_X8.h
@@ -43,7 +43,7 @@ class LimeSDR_MMX8 : public SDRDevice
         uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, double frequency, double phaseOffset = -1.0) override;
 
     int GetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel) override;
-    OpStatus SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, bool downconv) override;
+    OpStatus SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, int16_t index, bool downconv) override;
 
     double GetNCOOffset(uint8_t moduleIndex, TRXDir trx, uint8_t channel) override;
 

--- a/src/comms/USB/USBDMAEmulation.cpp
+++ b/src/comms/USB/USBDMAEmulation.cpp
@@ -8,6 +8,7 @@ namespace lime {
 
 // Too many async requests adds overhead and makes transfers timing consistency worse
 static constexpr int maxAsyncTransfers = 16;
+static constexpr uint32_t mappingBufferSize = 65536;
 
 USBDMAEmulation::USBDMAEmulation(std::shared_ptr<IUSB> port, uint8_t endpoint, DataTransferDirection dir)
     : port(port)
@@ -21,7 +22,7 @@ USBDMAEmulation::USBDMAEmulation(std::shared_ptr<IUSB> port, uint8_t endpoint, D
     mappings.resize(maxAsyncTransfers);
     for (auto& memoryBlock : mappings)
     {
-        memoryBlock.size = 65536;
+        memoryBlock.size = mappingBufferSize;
         memoryBlock.buffer = new uint8_t[memoryBlock.size];
     }
 
@@ -112,7 +113,7 @@ OpStatus USBDMAEmulation::EnableContinuous(bool enable, uint32_t maxTransferSize
     if (!enable)
         return status;
 
-    if (maxTransferSize == 0)
+    if (maxTransferSize == 0 || maxTransferSize > mappingBufferSize)
         return OpStatus::InvalidValue;
 
     if (dir != DataTransferDirection::DeviceToHost)
@@ -167,6 +168,8 @@ OpStatus USBDMAEmulation::SubmitRequest(uint64_t index, uint32_t bytesCount, Dat
 
     assert(bytesCount > 0);
     assert(index < mappings.size());
+    if (index >= mappings.size() || bytesCount == 0 || bytesCount > mappings[index].size)
+        return OpStatus::InvalidValue;
 
     std::unique_lock lck{ queuesMutex };
     if (!transfers.empty())

--- a/src/include/limesuiteng/SDRDevice.h
+++ b/src/include/limesuiteng/SDRDevice.h
@@ -190,10 +190,10 @@ class LIME_API SDRDevice
     /// @param moduleIndex The @ref Device_index "device index" to configure.
     /// @param trx The direction to configure.
     /// @param channel The @ref lime::LMS7002M::Channel "channel" to configure.
-    /// @param index The index of NCO memory table entry to use for NCO [0-15].
+    /// @param index The index of NCO memory table entry to use for NCO [0-15]; a negative value disables the NCO.
     /// @param downconv The spectrum control of the CMIX (true = downconvert, false = upconvert)
     /// @return The @ref lime::OpStatus "status" of the operation.
-    virtual OpStatus SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, uint8_t index, bool downconv) = 0;
+    virtual OpStatus SetNCOIndex(uint8_t moduleIndex, TRXDir trx, uint8_t channel, int16_t index, bool downconv) = 0;
 
     /// @brief Gets the current sample rate of the device.
     /// Returns device sample rate and optionally, the actual RF sample rate used in AFE ADCs and DACs.

--- a/src/logger/Logger.cpp
+++ b/src/logger/Logger.cpp
@@ -18,6 +18,7 @@ using namespace std::literals::string_literals;
 
 namespace lime {
 
+std::mutex Logger::handlerMutex;
 LogHandler Logger::logHandler{ Logger::defaultLogHandler };
 thread_local int Logger::_reportedErrorCode{ 0 };
 thread_local std::string Logger::_reportedErrorMessage{ ""s };
@@ -42,11 +43,17 @@ void Logger::defaultLogHandler(const LogLevel level, const std::string& message)
 
 void Logger::logHandlerWrapper(const LogLevel level, const std::string& message)
 {
-    logHandlerCString(level, message.c_str());
+    LogHandlerCString handler;
+    {
+        const std::lock_guard<std::mutex> lock(handlerMutex);
+        handler = logHandlerCString;
+    }
+    handler(level, message.c_str());
 }
 
 void registerLogHandler(const LogHandler handler)
 {
+    const std::lock_guard<std::mutex> lock(Logger::handlerMutex);
     Logger::logHandler = handler ? handler : Logger::defaultLogHandler;
     Logger::logHandlerCString = handler ? Logger::logHandlerCStringWrapper : Logger::defaultLogHandlerCString;
 }
@@ -84,7 +91,12 @@ void debug(const std::string& text)
 
 void log(const LogLevel level, const std::string& text)
 {
-    Logger::logHandler(level, text);
+    LogHandler handler;
+    {
+        const std::lock_guard<std::mutex> lock(Logger::handlerMutex);
+        handler = Logger::logHandler;
+    }
+    handler(level, text);
 }
 
 OpStatus ReportError(const OpStatus errnum)

--- a/src/logger/LoggerCString.cpp
+++ b/src/logger/LoggerCString.cpp
@@ -30,11 +30,17 @@ void Logger::defaultLogHandlerCString(const LogLevel level, const char* message)
 
 void Logger::logHandlerCStringWrapper(const LogLevel level, const char* message)
 {
-    Logger::logHandler(level, message);
+    LogHandler handler;
+    {
+        const std::lock_guard<std::mutex> lock(handlerMutex);
+        handler = logHandler;
+    }
+    handler(level, message);
 }
 
 void registerLogHandler(const LogHandlerCString handler)
 {
+    const std::lock_guard<std::mutex> lock(Logger::handlerMutex);
     Logger::logHandlerCString = handler ? handler : Logger::defaultLogHandlerCString;
     Logger::logHandler = handler ? Logger::logHandlerWrapper : Logger::defaultLogHandler;
 }
@@ -48,8 +54,14 @@ void log [[gnu::format(printf, 2, 0)]] (const LogLevel level, const char* format
 {
     char buff[4096];
     int ret = std::vsnprintf(buff, sizeof(buff), format, argList);
-    if (ret > 0)
-        Logger::logHandlerCString(level, buff);
+    if (ret <= 0)
+        return;
+    LogHandlerCString handler;
+    {
+        const std::lock_guard<std::mutex> lock(Logger::handlerMutex);
+        handler = Logger::logHandlerCString;
+    }
+    handler(level, buff);
 }
 
 void critical(const char* format, ...)

--- a/src/logger/LoggerInternal.h
+++ b/src/logger/LoggerInternal.h
@@ -3,6 +3,8 @@
 
 #include "limesuiteng/Logger.h"
 
+#include <mutex>
+
 #ifdef _MSC_VER
     #define thread_local __declspec(thread)
 #endif
@@ -18,6 +20,9 @@ class Logger
     static void defaultLogHandler(const LogLevel level, const std::string& message);
     static void logHandlerWrapper(const LogLevel level, const std::string& message);
 
+    // guards the handler pair below, which is swapped as a unit by registerLogHandler
+    // while worker threads read it; copy the handler under the lock, call it outside
+    static std::mutex handlerMutex;
     static LogHandlerCString logHandlerCString;
     static LogHandler logHandler;
 

--- a/src/streaming/TRXLooper.cpp
+++ b/src/streaming/TRXLooper.cpp
@@ -70,14 +70,12 @@ static int64_t UTC_to_UnixTime(const struct tm& calendarTime)
     return unixtime;
 }
 
-static int ReadySlots(uint32_t writer, uint32_t reader, uint32_t ringSize)
+// Hardware transfer counters are either free-running (PCIe, 64-bit) or wrap at
+// 16 bits (USB). A modular 16-bit subtraction yields the correct delta for both,
+// as long as fewer than 65536 transfers complete between polls.
+static int64_t CompletedTransfersDelta(uint64_t current, uint64_t previous)
 {
-    assert(writer < ringSize);
-    assert(reader < ringSize);
-    if (writer >= reader)
-        return writer - reader;
-    else
-        return ringSize - reader + writer;
+    return static_cast<uint16_t>(current - previous);
 }
 
 static constexpr int64_t ts_to_us(int64_t fs, int64_t ts)
@@ -700,7 +698,7 @@ void TRXLooper::ReceivePacketsLoop()
     int32_t Bps = 0;
     StreamPacket* userPkt = nullptr;
 
-    uint32_t lastHwIndex{ 0 };
+    uint64_t lastHwIndex{ 0 };
     DMATransactionCounter counters;
 
     assert(mRx.stagingPacket == nullptr); // should be clean start
@@ -717,7 +715,7 @@ void TRXLooper::ReceivePacketsLoop()
     while (mRx.terminate.load(std::memory_order_relaxed) == false)
     {
         IDMA::State dma{ mRxArgs.dma->GetCounters() };
-        int64_t counterDiff = ReadySlots(dma.transfersCompleted, lastHwIndex, 65536);
+        int64_t counterDiff = CompletedTransfersDelta(dma.transfersCompleted, lastHwIndex);
         lastHwIndex = dma.transfersCompleted;
         counters.completed += counterDiff;
 
@@ -1301,7 +1299,7 @@ void TRXLooper::TransmitPacketsLoop()
     while (mTx.terminate.load(std::memory_order_relaxed) == false)
     {
         IDMA::State dma{ mTxArgs.dma->GetCounters() };
-        int64_t counterDiff = ReadySlots(dma.transfersCompleted, lastHwIndex, 65536);
+        int64_t counterDiff = CompletedTransfersDelta(dma.transfersCompleted, lastHwIndex);
         lastHwIndex = dma.transfersCompleted;
         counters.completed += counterDiff;
 

--- a/src/streaming/TRXLooper.cpp
+++ b/src/streaming/TRXLooper.cpp
@@ -803,9 +803,18 @@ void TRXLooper::ReceivePacketsLoop()
         {
             if (!mRx.packetsPool->pop(&userPkt))
             {
+                // packet pool is exhausted: drop this buffer's data and hand it back to
+                // the hardware, otherwise the loop busy-spins on the same buffer at
+                // realtime priority, starving the consumer that would free the pool
                 ++stats.overrun;
                 overrun.add(1);
-                reportProblems = true;
+                mRxArgs.dma->BufferOwnership(currentBufferIndex, DataTransferDirection::HostToDevice);
+                const bool requestIRQ = (counters.requests % irqPeriod) == 0;
+                ++counters.requests;
+                mRxArgs.dma->SubmitRequest(currentBufferIndex, readSize, DataTransferDirection::DeviceToHost, requestIRQ);
+                if (mConfig.statusCallback)
+                    mConfig.statusCallback(false, &stats, mConfig.userData);
+                std::this_thread::yield();
                 continue;
             }
             userPkt->Reset();

--- a/src/streaming/TRXLooper.cpp
+++ b/src/streaming/TRXLooper.cpp
@@ -822,6 +822,14 @@ void TRXLooper::ReceivePacketsLoop()
             userPkt->meta.useTimestamp = true;
             userPkt->meta.flush = false;
         }
+        else if (userPkt->samples.empty())
+        {
+            // packet is being reused after a failed FIFO push; its Reset() zeroed the
+            // timestamp, so re-initialize the metadata from this buffer's first packet
+            userPkt->meta.timestamp = ExtractPacketTimestamp(mConfig, firstPkt, ticksPerSample);
+            userPkt->meta.useTimestamp = true;
+            userPkt->meta.flush = false;
+        }
 
         const int srcPktCount = mRxArgs.packetsToBatch;
         for (int i = 0; i < srcPktCount; ++i)
@@ -882,7 +890,12 @@ void TRXLooper::ReceivePacketsLoop()
 
         assert(userPkt);
         if (fifo->push(userPkt, false))
+        {
             userPkt = nullptr;
+            stats.packets += srcPktCount;
+            stats.timestamp = expectedTimestamp.GetTicks();
+            mRx.lastTimestamp.store(expectedTimestamp.GetTicks(), std::memory_order_relaxed);
+        }
         else
         {
             ++stats.overrun;
@@ -890,10 +903,6 @@ void TRXLooper::ReceivePacketsLoop()
             userPkt->Reset();
             reportProblems = true;
         }
-
-        stats.packets += srcPktCount;
-        stats.timestamp = expectedTimestamp.GetTicks();
-        mRx.lastTimestamp.store(expectedTimestamp.GetTicks(), std::memory_order_relaxed);
 
         mRxArgs.dma->BufferOwnership(currentBufferIndex, DataTransferDirection::HostToDevice);
         bool requestIRQ = (counters.requests % irqPeriod) == 0;


### PR DESCRIPTION
Third and final batched round from the stability audit (#274-#312), one signed commit per fix, via the agreed intermediate-branch workflow. This closes the remaining audit issues.

- **#280** - streaming: on Rx packet-pool exhaustion the loop now drops the buffer once, resubmits it, reports the overrun and yields, instead of busy-spinning at realtime priority
- **#282** - streaming: after an Rx FIFO overflow the reused packet gets its timestamp re-initialized and dropped batches are no longer counted as delivered
- **#283** - streaming: DMA transfer deltas use a modular 16-bit subtraction valid for both the USB wrapping counter and the PCIe free-running 64-bit counter
- **#289** - comms: USB DMA emulation rejects transfers larger than its 64 KiB mapping buffers
- **#292** - boards: XTRX/X3/Mini Configure propagates init, sample-rate and calibration failures instead of reporting Success
- **#293** - boards: the LPF cache is keyed by (module, direction, channel) so multi-chip boards no longer cross-read cached bandwidths
- **#294** - boards: MMX8 validates the module index everywhere (OutOfRange / neutral default) instead of silently clamping to module 0, throwing, or indexing unchecked
- **#295** - api: SetNCOIndex takes a signed index so the NCO-disable path is reachable, and validates the range before any register write
- **#305** - plugins: Soapy Rx and Tx streams share the bidirectional hardware stream with per-direction bookkeeping, so closing or deactivating one direction no longer tears down the other
- **#307** - logger: the global handler pair is swapped and read under a mutex, handlers are copied out before the call

Fixes #280
Fixes #282
Fixes #283
Fixes #289
Fixes #292
Fixes #293
Fixes #294
Fixes #295
Fixes #305
Fixes #307

Notes for review:
- #295 changes the `SDRDevice::SetNCOIndex` signature (`uint8_t` -> `int16_t` index) so the documented negative-disable sentinel used by the legacy `LMS_SetNCOIndex` actually works; all in-tree implementers and callers are updated.
- #305 keeps the single bidirectional hardware stream (two concurrent RFStreams would fight over the same DMA channels) and adds per-direction setup/active tracking; mismatched formats across directions are rejected with a clear error.
- The Tx timestamp conversion still uses the Rx sample rate on purpose: hardware timestamps tick in the Rx counter domain.

Verification: full CMake build clean (library, plugins, CLI, GUI); all 54 unit tests pass (`gtest-runner`). The streaming-loop changes are hardware-path code reviewed carefully but exercised only by the software tests, so an on-device smoke run of Rx/Tx streaming before merge would be a sensible extra check.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)